### PR TITLE
Limit page width for mobile

### DIFF
--- a/Roulette/Layout/MainLayout.razor.css
+++ b/Roulette/Layout/MainLayout.razor.css
@@ -1,3 +1,7 @@
 .page {
     padding: 1rem;
+    width: 100%;
+    max-width: 400px;
+    margin-left: auto;
+    margin-right: auto;
 }


### PR DESCRIPTION
## Summary
- set `.page` width to fill the screen up to 400px

## Testing
- `dotnet build Roulette.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6887362d9894832c89711f854a084a6b