### PR TITLE
Add center dot to roulette wheel

### DIFF
--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -55,6 +55,11 @@
             ctx.restore();
             current += slice;
         }
+        // draw center dot - adjustable size by radius ratio
+        ctx.beginPath();
+        ctx.fillStyle = 'black';
+        ctx.arc(0, 0, radius * 0.05, 0, 2 * Math.PI);
+        ctx.fill();
         ctx.restore();
     }
 


### PR DESCRIPTION
## Summary
- draw a small black dot at the center of the roulette canvas

## Testing
- `dotnet build Roulette.sln`

------
https://chatgpt.com/codex/tasks/task_e_68873e7427e8832c9cd8f2112175f2c6