### PR TITLE
Improve hit count display

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -27,12 +27,26 @@
     </div>
 </div>
 <div class="text-center mt-2">
-    <ul class="count-list">
-        @foreach (var item in items)
-        {
-            <li>@item.Text: @item.Count</li>
-        }
-    </ul>
+    <table class="table table-sm count-table">
+        <thead>
+            <tr>
+                <th>項目</th>
+                <th class="text-end">回数</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in items)
+            {
+                <tr>
+                    <td>
+                        <span class="color-box" style="background-color:@item.Color"></span>
+                        @item.Text
+                    </td>
+                    <td class="text-end">@item.Count</td>
+                </tr>
+            }
+        </tbody>
+    </table>
 </div>
 <div class="text-center mt-2">
     <button class="btn btn-secondary ms-2" @onclick="OpenManage">一覧</button>

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -78,8 +78,17 @@ canvas {
     font-weight: bold;
 }
 
-.count-list {
-    list-style: none;
-    padding: 0;
-    margin-bottom: 0.5rem;
+.count-table {
+    margin: 0 auto 0.5rem auto;
+    max-width: 300px;
+}
+
+.color-box {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    margin-right: 4px;
+    vertical-align: middle;
+    border: 1px solid rgba(0,0,0,0.2);
+    border-radius: 2px;
 }


### PR DESCRIPTION
## Summary
- redesign hit count section on main page
- style hit count table with color indicator squares

## Testing
- `dotnet restore`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688748e58c60832c92a6fe18090f825c