### PR TITLE
Add collapsible counts list

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -27,26 +27,30 @@
     </div>
 </div>
 <div class="text-center mt-2">
-    <table class="table table-sm count-table">
-        <thead>
-            <tr>
-                <th>項目</th>
-                <th class="text-end">回数</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach (var item in items)
-            {
+    <h5 class="count-header" @onclick="ToggleCounts">当たり回数 @(showCounts ? "▲" : "▼")</h5>
+    @if (showCounts)
+    {
+        <table class="table table-sm count-table">
+            <thead>
                 <tr>
-                    <td>
-                        <span class="color-box" style="background-color:@item.Color"></span>
-                        @item.Text
-                    </td>
-                    <td class="text-end">@item.Count</td>
+                    <th>項目</th>
+                    <th class="text-end">回数</th>
                 </tr>
-            }
-        </tbody>
-    </table>
+            </thead>
+            <tbody>
+                @foreach (var item in items)
+                {
+                    <tr>
+                        <td>
+                            <span class="color-box" style="background-color:@item.Color"></span>
+                            @item.Text
+                        </td>
+                        <td class="text-end">@item.Count</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
 </div>
 <div class="text-center mt-2">
     <button class="btn btn-secondary ms-2" @onclick="OpenManage">一覧</button>
@@ -76,6 +80,7 @@
     private bool isSpinning;
     private bool isStopping;
     private bool showOverlay;
+    private bool showCounts;
     private string overlayText = string.Empty;
     private string overlayColor = "white";
     private string overlayTextColor = "black";
@@ -143,6 +148,11 @@
 
         isSpinning = !isSpinning;
         await JS.InvokeVoidAsync("rouletteHelper.toggleSpin");
+    }
+
+    private void ToggleCounts()
+    {
+        showCounts = !showCounts;
     }
 
     [JSInvokable]

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -83,6 +83,11 @@ canvas {
     max-width: 300px;
 }
 
+.count-header {
+    cursor: pointer;
+    user-select: none;
+}
+
 .color-box {
     display: inline-block;
     width: 12px;


### PR DESCRIPTION
## Summary
- add a tappable header for the spin count list
- collapse counts by default and toggle with `ToggleCounts`

## Testing
- `dotnet build Roulette/Roulette.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688757038574832cb4da1a394688c3c6