### PR TITLE
Improve roulette rendering on high‑DPI displays

### DIFF
--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -105,6 +105,16 @@
         canvas = document.getElementById(id);
         if (!canvas) return;
         ctx = canvas.getContext('2d');
+
+        const dpr = window.devicePixelRatio || 1;
+        const displayWidth = canvas.clientWidth;
+        const displayHeight = canvas.clientHeight;
+        if (canvas.width !== displayWidth * dpr || canvas.height !== displayHeight * dpr) {
+            canvas.width = displayWidth * dpr;
+            canvas.height = displayHeight * dpr;
+        }
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
         items = Array.isArray(itemsArr) ? itemsArr : Array.from(itemsArr || []);
         dotNetHelper = dotNetRef || null;
         computeAngles();


### PR DESCRIPTION
## Summary
- scale canvas based on `devicePixelRatio` when initializing so the wheel renders crisply

## Testing
- `dotnet build Roulette.sln -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_68875c23a5a4832c86baf4ca036ccfae