### PR TITLE
Fix canvas scaling

### DIFF
--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -112,6 +112,8 @@
         if (canvas.width !== displayWidth * dpr || canvas.height !== displayHeight * dpr) {
             canvas.width = displayWidth * dpr;
             canvas.height = displayHeight * dpr;
+            canvas.style.width = displayWidth + 'px';
+            canvas.style.height = displayHeight + 'px';
         }
         ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 


### PR DESCRIPTION
## Summary
- ensure canvas scaling doesn't grow visually after DPI adjustments

## Testing
- `dotnet build Roulette/Roulette.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68875e633e30832cabdbfbd194a34a88