### PR TITLE
Refactor repeated storage logic

### DIFF
--- a/Roulette/Models/RouletteConfig.cs
+++ b/Roulette/Models/RouletteConfig.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.JSInterop;
 
 namespace Roulette.Models;
 
@@ -53,5 +54,17 @@ public class RouletteConfig
         catch { }
 
         return list;
+    }
+
+    public static async Task<List<RouletteConfig>> LoadAsync(IJSRuntime js)
+    {
+        var json = await js.InvokeAsync<string>("localStorage.getItem", "rouletteConfigs");
+        return FromJson(json);
+    }
+
+    public static async Task SaveAsync(IJSRuntime js, IEnumerable<RouletteConfig> configs)
+    {
+        var json = JsonSerializer.Serialize(configs);
+        await js.InvokeVoidAsync("localStorage.setItem", "rouletteConfigs", json);
     }
 }

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -94,8 +94,7 @@
         if (firstRender || currentId != Id)
         {
             currentId = Id;
-            var configJson = await JS.InvokeAsync<string>("localStorage.getItem", "rouletteConfigs");
-            var configs = RouletteConfig.FromJson(configJson);
+            var configs = await RouletteConfig.LoadAsync(JS);
 
             if (string.IsNullOrEmpty(Id))
             {
@@ -220,14 +219,12 @@
 
     private async Task SaveCountsAsync()
     {
-        var configJson = await JS.InvokeAsync<string>("localStorage.getItem", "rouletteConfigs");
-        var configs = RouletteConfig.FromJson(configJson);
+        var configs = await RouletteConfig.LoadAsync(JS);
         var cfg = configs.FirstOrDefault(c => c.Id == Id);
         if (cfg is not null)
         {
             cfg.Items = items.ToList();
-            var json = JsonSerializer.Serialize(configs);
-            await JS.InvokeVoidAsync("localStorage.setItem", "rouletteConfigs", json);
+            await RouletteConfig.SaveAsync(JS, configs);
         }
     }
 

--- a/Roulette/Pages/Manage.razor
+++ b/Roulette/Pages/Manage.razor
@@ -53,8 +53,7 @@ else
             return;
         }
 
-        var configJson = await JS.InvokeAsync<string>("localStorage.getItem", "rouletteConfigs");
-        configs = RouletteConfig.FromJson(configJson);
+        configs = await RouletteConfig.LoadAsync(JS);
 
         if (configs.Count == 0)
         {
@@ -82,8 +81,7 @@ else
         var cfg = configs.FirstOrDefault(c => c.Id == id);
         if (cfg is not null && configs.Remove(cfg))
         {
-            var json = JsonSerializer.Serialize(configs);
-            await JS.InvokeVoidAsync("localStorage.setItem", "rouletteConfigs", json);
+            await RouletteConfig.SaveAsync(JS, configs);
             StateHasChanged();
         }
     }

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -56,8 +56,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var configsJson = await JS.InvokeAsync<string>("localStorage.getItem", "rouletteConfigs");
-        configs = RouletteConfig.FromJson(configsJson);
+        configs = await RouletteConfig.LoadAsync(JS);
 
         if (!string.IsNullOrEmpty(Id))
         {
@@ -85,21 +84,16 @@
         }
     }
 
-    private void MoveUp(int index)
+    private void MoveItem(int index, int offset)
     {
-        if (index > 0)
-        {
-            (items[index - 1], items[index]) = (items[index], items[index - 1]);
-        }
+        var newIndex = index + offset;
+        if (newIndex < 0 || newIndex >= items.Count) return;
+        (items[newIndex], items[index]) = (items[index], items[newIndex]);
     }
 
-    private void MoveDown(int index)
-    {
-        if (index < items.Count - 1)
-        {
-            (items[index + 1], items[index]) = (items[index], items[index + 1]);
-        }
-    }
+    private void MoveUp(int index) => MoveItem(index, -1);
+
+    private void MoveDown(int index) => MoveItem(index, 1);
 
     private void ResetAllCounts()
     {
@@ -129,8 +123,7 @@
         currentConfig.Items = arr;
         currentConfig.AutoAdjustSize = autoAdjustSize;
 
-        var json = JsonSerializer.Serialize(configs);
-        await JS.InvokeVoidAsync("localStorage.setItem", "rouletteConfigs", json);
+        await RouletteConfig.SaveAsync(JS, configs);
         await JS.InvokeVoidAsync("localStorage.setItem", "rouletteItems", JsonSerializer.Serialize(arr));
         Nav.NavigateTo($"{currentConfig.Id}");
     }


### PR DESCRIPTION
## Summary
- extract helper methods `RouletteConfig.LoadAsync` and `RouletteConfig.SaveAsync`
- update pages to use these helpers
- combine item move logic in `Setting.razor`

## Testing
- `dotnet build Roulette/Roulette.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68877a998368832c815ad77b0399761c