### PR TITLE
Add export config feature

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -36,6 +36,7 @@
 
 <div class="mt-2">
     <button class="btn btn-primary" @onclick="Save">保存</button>
+    <button class="btn btn-secondary ms-2" @onclick="Export">書き出し</button>
     <button class="btn btn-secondary ms-2" @onclick="Back">戻る</button>
 </div>
 
@@ -126,6 +127,19 @@
         await RouletteConfig.SaveAsync(JS, configs);
         await JS.InvokeVoidAsync("localStorage.setItem", "rouletteItems", JsonSerializer.Serialize(arr));
         Nav.NavigateTo($"{currentConfig.Id}");
+    }
+
+    private async Task Export()
+    {
+        var cfg = new RouletteConfig
+        {
+            Name = configName,
+            Items = items.ToList(),
+            AutoAdjustSize = autoAdjustSize
+        };
+        var json = JsonSerializer.Serialize(cfg);
+        var fileName = string.IsNullOrWhiteSpace(configName) ? "config.json" : $"{configName}.json";
+        await JS.InvokeVoidAsync("downloadFile", fileName, json);
     }
 
     private void Back()

--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -211,4 +211,19 @@
             }
         }
     };
+
+    window.downloadFile = function (fileName, content) {
+        try {
+            const blob = new Blob([content], { type: 'text/plain' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = fileName;
+            a.style.display = 'none';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        } catch { }
+    };
 })();


### PR DESCRIPTION
## Summary
- allow exporting roulette configs from settings page
- implement `downloadFile` helper in JS

## Testing
- `dotnet build Roulette.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6888127ae728832c8c4c2c5776d15dac