### PR TITLE
Exclude id from exported settings

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -131,13 +131,13 @@
 
     private async Task Export()
     {
-        var cfg = new RouletteConfig
+        var exportObj = new
         {
             Name = configName,
             Items = items.ToList(),
             AutoAdjustSize = autoAdjustSize
         };
-        var json = JsonSerializer.Serialize(cfg);
+        var json = JsonSerializer.Serialize(exportObj);
         var fileName = string.IsNullOrWhiteSpace(configName) ? "config.json" : $"{configName}.json";
         await JS.InvokeVoidAsync("downloadFile", fileName, json);
     }


### PR DESCRIPTION
## Summary
- fix settings export to exclude Id field

## Testing
- `dotnet build Roulette.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6888316a9938832c84590dd03dea927a