### PR TITLE
Move export to Manage page

### DIFF
--- a/Roulette/Models/JsonUtil.cs
+++ b/Roulette/Models/JsonUtil.cs
@@ -1,0 +1,8 @@
+namespace Roulette.Models;
+
+using System.Text.Json;
+
+public static class JsonUtil
+{
+    public static readonly JsonSerializerOptions WebOptions = new(JsonSerializerDefaults.Web);
+}

--- a/Roulette/Models/RouletteConfig.cs
+++ b/Roulette/Models/RouletteConfig.cs
@@ -5,7 +5,6 @@ namespace Roulette.Models;
 
 public class RouletteConfig
 {
-    private static readonly JsonSerializerOptions s_opt = new(JsonSerializerDefaults.Web);
 
     public string Id { get; set; } = Guid.NewGuid().ToString("N");
 
@@ -27,7 +26,7 @@ public class RouletteConfig
             {
                 foreach (var el in doc.RootElement.EnumerateArray())
                 {
-                    var cfg = el.Deserialize<RouletteConfig>(s_opt) ?? new RouletteConfig();
+                    var cfg = el.Deserialize<RouletteConfig>(JsonUtil.WebOptions) ?? new RouletteConfig();
                     if (!el.TryGetProperty(nameof(AutoAdjustSize), out _))
                     {
                         cfg.AutoAdjustSize = true;
@@ -41,7 +40,7 @@ public class RouletteConfig
 
         try
         {
-            var legacy = JsonSerializer.Deserialize<Dictionary<string, RouletteItem[]>>(json, s_opt);
+            var legacy = JsonSerializer.Deserialize<Dictionary<string, RouletteItem[]>>(json, JsonUtil.WebOptions);
             if (legacy is { })
             {
                 list = [.. legacy.Select(kvp => new RouletteConfig
@@ -66,7 +65,7 @@ public class RouletteConfig
 
     public static async Task SaveAsync(IJSRuntime js, IEnumerable<RouletteConfig> configs)
     {
-        var json = JsonSerializer.Serialize(configs, s_opt);
+        var json = JsonSerializer.Serialize(configs, JsonUtil.WebOptions);
         await js.InvokeVoidAsync("localStorage.setItem", "rouletteConfigs", json);
     }
 }

--- a/Roulette/Pages/Manage.razor
+++ b/Roulette/Pages/Manage.razor
@@ -5,6 +5,7 @@
 @using System.Collections.Generic
 @using System.Linq
 @using System
+@using Roulette.Models
 
 <PageTitle>設定一覧 - ルーレット</PageTitle>
 
@@ -29,6 +30,7 @@ else
                 <span>@cfg.Name</span>
                 <span>
                     <button class="btn btn-sm btn-primary me-1" @onclick="() => SelectConfig(cfg.Id)">選択</button>
+                    <button class="btn btn-sm btn-secondary me-1" @onclick="() => ExportConfig(cfg)">書き出し</button>
                     <button class="btn btn-sm btn-danger" @onclick="() => DeleteConfig(cfg.Id)">削除</button>
                 </span>
             </li>
@@ -72,6 +74,21 @@ else
     private void SelectConfig(string id)
     {
         Nav.NavigateTo($"{id}");
+    }
+
+    private async Task ExportConfig(RouletteConfig cfg)
+    {
+        var exportObj = new
+        {
+            cfg.Name,
+            cfg.Items,
+            cfg.AutoAdjustSize
+        };
+        var json = JsonSerializer.Serialize(exportObj, JsonUtil.WebOptions);
+        var timestamp = DateTime.Now.ToString("yyyyMMddHHmmss");
+        var baseName = string.IsNullOrWhiteSpace(cfg.Name) ? "config" : cfg.Name;
+        var fileName = $"{baseName}_{timestamp}.json";
+        await JS.InvokeVoidAsync("downloadFile", fileName, json);
     }
 
     private async Task DeleteConfig(string id)

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -5,6 +5,7 @@
 @using System.Collections.Generic
 @using System.Linq
 @using System
+@using Roulette.Models
 
 <PageTitle>設定『@configName』 - ルーレット</PageTitle>
 
@@ -37,7 +38,6 @@
 
 <div class="mt-2">
     <button class="btn btn-primary" @onclick="Save">保存</button>
-    <button class="btn btn-secondary ms-2" @onclick="Export">書き出し</button>
     <button class="btn btn-secondary ms-2" @onclick="Back">戻る</button>
 </div>
 
@@ -130,21 +130,6 @@
         Nav.NavigateTo($"{currentConfig.Id}");
     }
 
-    private async Task Export()
-    {
-        var exportObj = new
-        {
-            Name = configName,
-            Items = items.ToList(),
-            AutoAdjustSize = autoAdjustSize
-        };
-        var opt = new JsonSerializerOptions(JsonSerializerDefaults.Web);
-        var json = JsonSerializer.Serialize(exportObj, opt);
-        var timestamp = DateTime.Now.ToString("yyyyMMddHHmmss");
-        var baseName = string.IsNullOrWhiteSpace(configName) ? "config" : configName;
-        var fileName = $"{baseName}_{timestamp}.json";
-        await JS.InvokeVoidAsync("downloadFile", fileName, json);
-    }
 
     private void Back()
     {


### PR DESCRIPTION
## Summary
- add `JsonUtil` for shared `JsonSerializerOptions`
- export settings from Manage page instead of Setting page
- add export button to each config list item
- omit `Id` when exporting configs

## Testing
- `dotnet build Roulette/Roulette.csproj -nologo`


------
https://chatgpt.com/codex/tasks/task_e_68883a18be00832c82ef92394f8a0af1