### PR TITLE
Enable clicking config rows to open setting

### DIFF
--- a/Roulette/Pages/Manage.razor
+++ b/Roulette/Pages/Manage.razor
@@ -26,12 +26,11 @@ else
     <ul class="list-group">
         @foreach (var cfg in configs)
         {
-            <li class="list-group-item d-flex justify-content-between align-items-center">
+            <li class="list-group-item list-group-item-action d-flex justify-content-between align-items-center config-item" @onclick="() => SelectConfig(cfg.Id)">
                 <span>@cfg.Name</span>
                 <span>
-                    <button class="btn btn-sm btn-primary me-1" @onclick="() => SelectConfig(cfg.Id)">選択</button>
-                    <button class="btn btn-sm btn-secondary me-1" @onclick="() => ExportConfig(cfg)">書き出し</button>
-                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteConfig(cfg.Id)">削除</button>
+                    <button class="btn btn-sm btn-secondary me-1" @onclick="() => ExportConfig(cfg)" @onclick:stopPropagation="true">書き出し</button>
+                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteConfig(cfg.Id)" @onclick:stopPropagation="true">削除</button>
                 </span>
             </li>
         }

--- a/Roulette/Pages/Manage.razor.css
+++ b/Roulette/Pages/Manage.razor.css
@@ -2,6 +2,10 @@
     flex: 1;
 }
 
+.config-item {
+    cursor: pointer;
+}
+
 .commit-hash {
     position: fixed;
     bottom: 0.5rem;


### PR DESCRIPTION
## Summary
- make each configuration list item act as a button
- remove the explicit "選択" button
- stop propagation from export/delete buttons
- style clickable list items with a pointer cursor

## Testing
- `dotnet build Roulette/Roulette.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6888473ede18832ca37e0a9ac0dbd040