### PR TITLE
Center overlay on roulette wheel

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -16,6 +16,14 @@
 <div class="roulette-container">
     <canvas id="rouletteCanvas" width="300" height="300" @onclick="ToggleSpin"></canvas>
     <div class="pointer"></div>
+    @if (showOverlay)
+    {
+        <div class="overlay" @onclick="HideOverlay">
+            <div class="overlay-content" style="background-color:@overlayColor;color:@overlayTextColor;">
+                @overlayText
+            </div>
+        </div>
+    }
 </div>
 <div class="mt-3 text-center">
     <button class="btn btn-primary start-stop-button" @onclick="ToggleSpin" disabled="@((isStopping) || (isSpinning && autoStop))">@(isSpinning ? "ストップ" : "スタート")</button>
@@ -56,14 +64,6 @@
     <button class="btn btn-secondary ms-2" @onclick="OpenManage">一覧</button>
     <button class="btn btn-secondary settings-button" @onclick="OpenSettings">設定</button>
 </div>
-@if (showOverlay)
-{
-    <div class="overlay" @onclick="HideOverlay">
-        <div class="overlay-content" style="background-color:@overlayColor;color:@overlayTextColor;">
-            @overlayText
-        </div>
-    </div>
-}
 
 @code {
     [Parameter]

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -28,7 +28,7 @@ canvas {
 }
 
 .overlay {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     width: 100%;


### PR DESCRIPTION
## Summary
- move overlay markup inside `roulette-container`
- make overlay absolutely positioned instead of fixed

## Testing
- `dotnet build Roulette.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688884007c14832ca27b0d47c0bc2666