### PR TITLE
Add item multiplier feature

### DIFF
--- a/Roulette/Models/RouletteConfig.cs
+++ b/Roulette/Models/RouletteConfig.cs
@@ -14,6 +14,8 @@ public class RouletteConfig
 
     public bool AutoAdjustSize { get; set; } = true;
 
+    public int ItemMultiplier { get; set; } = 1;
+
     public static List<RouletteConfig> FromJson(string? json)
     {
         var list = new List<RouletteConfig>();
@@ -30,6 +32,10 @@ public class RouletteConfig
                     if (!el.TryGetProperty(nameof(AutoAdjustSize), out _))
                     {
                         cfg.AutoAdjustSize = true;
+                    }
+                    if (!el.TryGetProperty(nameof(ItemMultiplier), out _))
+                    {
+                        cfg.ItemMultiplier = 1;
                     }
                     list.Add(cfg);
                 }
@@ -48,7 +54,8 @@ public class RouletteConfig
                     Id = Guid.NewGuid().ToString("N"),
                     Name = kvp.Key,
                     Items = [.. kvp.Value],
-                    AutoAdjustSize = true
+                    AutoAdjustSize = true,
+                    ItemMultiplier = 1
                 })];
             }
         }

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -46,7 +46,7 @@
                 </tr>
             </thead>
             <tbody>
-                @foreach (var item in items)
+                @foreach (var item in items.Distinct())
                 {
                     <tr>
                         <td>
@@ -111,7 +111,13 @@
                 return;
             }
 
-            items = cfg.Items.ToArray();
+            var multiplier = cfg.ItemMultiplier <= 1 ? 1 : cfg.ItemMultiplier;
+            var list = new List<RouletteItem>(cfg.Items.Count * multiplier);
+            for (int i = 0; i < multiplier; i++)
+            {
+                list.AddRange(cfg.Items);
+            }
+            items = list.ToArray();
             selectedConfig = cfg.Name;
             autoAdjustSize = cfg.AutoAdjustSize;
 
@@ -233,7 +239,7 @@
         var cfg = configs.FirstOrDefault(c => c.Id == Id);
         if (cfg is not null)
         {
-            cfg.Items = items.ToList();
+            cfg.Items = items.Distinct().ToList();
             await RouletteConfig.SaveAsync(JS, configs);
         }
     }

--- a/Roulette/Pages/Manage.razor
+++ b/Roulette/Pages/Manage.razor
@@ -76,7 +76,8 @@ else
         {
             cfg.Name,
             cfg.Items,
-            cfg.AutoAdjustSize
+            cfg.AutoAdjustSize,
+            cfg.ItemMultiplier
         };
         var json = JsonSerializer.Serialize(exportObj, JsonUtil.WebOptions);
         var timestamp = DateTime.Now.ToString("yyyyMMddHHmmss");

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -21,6 +21,11 @@
     <label class="form-check-label" for="autoSize">大きさ自動調整</label>
 </div>
 
+<div class="mb-3">
+    <label class="form-label">表示倍数</label>
+    <input type="number" class="form-control" @bind="itemMultiplier" min="1" />
+</div>
+
 @for (int i = 0; i < items.Count; i++)
 {
     var index = i;
@@ -55,6 +60,7 @@
     private List<RouletteConfig> configs = new();
     private RouletteConfig? currentConfig;
     private bool autoAdjustSize = true;
+    private int itemMultiplier = 1;
 
     protected override async Task OnInitializedAsync()
     {
@@ -68,6 +74,7 @@
                 configName = currentConfig.Name;
                 items = currentConfig.Items.ToList();
                 autoAdjustSize = currentConfig.AutoAdjustSize;
+                itemMultiplier = currentConfig.ItemMultiplier;
             }
         }
         // When creating a new configuration, keep the default A/B/C items
@@ -124,6 +131,7 @@
         currentConfig.Name = configName;
         currentConfig.Items = arr;
         currentConfig.AutoAdjustSize = autoAdjustSize;
+        currentConfig.ItemMultiplier = itemMultiplier;
 
         await RouletteConfig.SaveAsync(JS, configs);
         await JS.InvokeVoidAsync("localStorage.setItem", "rouletteItems", JsonSerializer.Serialize(arr));


### PR DESCRIPTION
## Summary
- allow configs to repeat each item when displayed
- save `ItemMultiplier` in settings and config
- export `ItemMultiplier`
- deduplicate items when saving counts
- display counts only once per item

## Testing
- `dotnet build Roulette.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6888aae8d5ac832ca838649cc40a0b9a