### PR TITLE
Fix multiplier input layout

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -21,9 +21,9 @@
     <label class="form-check-label" for="autoSize">大きさ自動調整</label>
 </div>
 
-<div class="mb-3">
-    <label class="form-label">表示倍数</label>
-    <input type="number" class="form-control" @bind="itemMultiplier" min="1" />
+<div class="mb-3 d-flex align-items-center">
+    <label class="form-label me-2 mb-0">表示倍数</label>
+    <input type="number" class="form-control multiplier-input" @bind="itemMultiplier" min="1" />
 </div>
 
 @for (int i = 0; i < items.Count; i++)

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -22,3 +22,7 @@
     margin-left: 4px;
     flex: unset;
 }
+
+.multiplier-input {
+    width: 6rem;
+}


### PR DESCRIPTION
## Summary
- align the display multiplier label and textbox horizontally
- shrink the multiplier textbox using new style

## Testing
- `dotnet build Roulette/Roulette.csproj -clp:ErrorsOnly`


------
https://chatgpt.com/codex/tasks/task_e_6888bda22544832c9012e61432020e02