### PR TITLE
Add delay before result overlay

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -180,6 +180,7 @@
                 overlayLeft = center[0];
                 overlayTop = center[1];
             }
+            await Task.Delay(500);
             showOverlay = true;
 
             if (!string.IsNullOrWhiteSpace(item.Text))


### PR DESCRIPTION
## Summary
- add a 0.5s delay before showing the result overlay when the roulette stops

## Testing
- `dotnet build Roulette/Roulette.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6888c3db9644832c8c0f3a4dc029eece