### PR TITLE
Improve cursor on roulette wheel

### DIFF
--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -2,6 +2,9 @@ canvas {
     display: block;
     margin: 0 auto;
     touch-action: none;
+    cursor: pointer;
+    /* Limit pointer events to the circle so the cursor only changes on the wheel */
+    clip-path: circle(50% at 50% 50%);
     border-radius: 50%;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     background: radial-gradient(circle at center, #fff 0%, #eee 100%);


### PR DESCRIPTION
## Summary
- show pointer cursor when hovering over the roulette wheel
- restrict pointer events to the circular area using `clip-path`

## Testing
- `dotnet build Roulette/Roulette.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6888ca3dcff0832ca9d336d5dfe0bfee