### PR TITLE
Add global setting page for board size

### DIFF
--- a/Roulette/Layout/MainLayout.razor.css
+++ b/Roulette/Layout/MainLayout.razor.css
@@ -1,7 +1,8 @@
 .page {
     padding: 1rem;
     width: 100%;
-    max-width: 400px;
+    /* Allow large board sizes to remain centered */
+    max-width: none;
     margin-left: auto;
     margin-right: auto;
 }

--- a/Roulette/Models/AppSettings.cs
+++ b/Roulette/Models/AppSettings.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using Microsoft.JSInterop;
+
+namespace Roulette.Models;
+
+public class AppSettings
+{
+    public int BoardSize { get; set; } = 300;
+
+    public static AppSettings FromJson(string? json)
+    {
+        if (string.IsNullOrEmpty(json)) return new AppSettings();
+        try
+        {
+            return JsonSerializer.Deserialize<AppSettings>(json, JsonUtil.WebOptions) ?? new AppSettings();
+        }
+        catch
+        {
+            return new AppSettings();
+        }
+    }
+
+    public static async Task<AppSettings> LoadAsync(IJSRuntime js)
+    {
+        var json = await js.InvokeAsync<string>("localStorage.getItem", "appSettings");
+        return FromJson(json);
+    }
+
+    public static async Task SaveAsync(IJSRuntime js, AppSettings settings)
+    {
+        var json = JsonSerializer.Serialize(settings, JsonUtil.WebOptions);
+        await js.InvokeVoidAsync("localStorage.setItem", "appSettings", json);
+    }
+}

--- a/Roulette/Models/RouletteConfig.cs
+++ b/Roulette/Models/RouletteConfig.cs
@@ -16,6 +16,7 @@ public class RouletteConfig
 
     public int ItemMultiplier { get; set; } = 1;
 
+
     public static List<RouletteConfig> FromJson(string? json)
     {
         var list = new List<RouletteConfig>();

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -6,6 +6,7 @@
 @using System.Globalization
 @using System.Collections.Generic
 @using System.Linq
+@using Roulette.Models
 @implements IDisposable
 
 <PageTitle>@selectedConfig - ルーレット</PageTitle>
@@ -13,8 +14,8 @@
 <div class="text-center config-header">
     <h4>@(string.IsNullOrEmpty(selectedConfig) ? "設定なし" : selectedConfig)</h4>
 </div>
-<div id="rouletteContainer" class="roulette-container">
-    <canvas id="rouletteCanvas" width="300" height="300" @onclick="ToggleSpin"></canvas>
+<div id="rouletteContainer" class="roulette-container" style="@($"width:{boardSize}px")">
+    <canvas id="rouletteCanvas" width="@boardSize" height="@boardSize" @onclick="ToggleSpin"></canvas>
     <div class="pointer"></div>
     @if (showOverlay)
     {
@@ -62,6 +63,7 @@
 </div>
 <div class="text-center mt-2">
     <button class="btn btn-secondary ms-2" @onclick="OpenManage">一覧</button>
+    <button class="btn btn-secondary ms-2" @onclick="OpenPreference">環境設定</button>
     <button class="btn btn-secondary settings-button" @onclick="OpenSettings">設定</button>
 </div>
 
@@ -90,12 +92,16 @@
     private string selectedConfig = string.Empty;
     private bool autoAdjustSize = true;
     private bool autoStop = true;
+    private int boardSize = 300;
+    private AppSettings settings = new();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender || currentId != Id)
         {
             currentId = Id;
+            settings = await AppSettings.LoadAsync(JS);
+            boardSize = settings.BoardSize;
             var configs = await RouletteConfig.LoadAsync(JS);
 
             if (string.IsNullOrEmpty(Id))
@@ -281,5 +287,10 @@
     private void OpenManage()
     {
         Nav.NavigateTo("");
+    }
+
+    private void OpenPreference()
+    {
+        Nav.NavigateTo("preference");
     }
 }

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -95,13 +95,17 @@
     private int boardSize = 300;
     private AppSettings settings = new();
 
+    protected override async Task OnInitializedAsync()
+    {
+        settings = await AppSettings.LoadAsync(JS);
+        boardSize = settings.BoardSize;
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender || currentId != Id)
         {
             currentId = Id;
-            settings = await AppSettings.LoadAsync(JS);
-            boardSize = settings.BoardSize;
             var configs = await RouletteConfig.LoadAsync(JS);
 
             if (string.IsNullOrEmpty(Id))

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -12,7 +12,6 @@ canvas {
 
 .roulette-container {
     position: relative;
-    width: 300px;
     margin: 0 auto;
     padding-top: 25px;
 }

--- a/Roulette/Pages/Manage.razor
+++ b/Roulette/Pages/Manage.razor
@@ -13,6 +13,7 @@
 
 <div class="mb-3 d-flex">
     <button class="btn btn-primary" @onclick="NewConfig">新規作成</button>
+    <button class="btn btn-secondary ms-2" @onclick="OpenPreference">環境設定</button>
     <button class="btn btn-secondary ms-auto" @onclick="TriggerImport">設定ファイル取り込み</button>
     <InputFile OnChange="ImportConfig" style="display:none" @ref="importInput" accept="application/json" />
 </div>
@@ -63,6 +64,11 @@ else
     private void NewConfig()
     {
         Nav.NavigateTo("setting");
+    }
+
+    private void OpenPreference()
+    {
+        Nav.NavigateTo("preference");
     }
 
     private void SelectConfig(string id)

--- a/Roulette/Pages/Preference.razor
+++ b/Roulette/Pages/Preference.razor
@@ -1,0 +1,41 @@
+@page "/preference"
+@inject IJSRuntime JS
+@inject NavigationManager Nav
+@using Roulette.Models
+
+<PageTitle>環境設定 - ルーレット</PageTitle>
+
+<h3>環境設定</h3>
+
+<div class="mb-3 d-flex align-items-center">
+    <label class="form-label me-2 mb-0">盤の大きさ(px)</label>
+    <input type="number" class="form-control board-size-input" @bind="boardSize" min="100" />
+</div>
+
+<div class="mb-3 d-flex">
+    <button class="btn btn-primary ms-auto" @onclick="Save">保存</button>
+    <button class="btn btn-secondary ms-2" @onclick="Back">戻る</button>
+</div>
+
+@code {
+    private int boardSize = 300;
+    private AppSettings settings = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        settings = await AppSettings.LoadAsync(JS);
+        boardSize = settings.BoardSize;
+    }
+
+    private async Task Save()
+    {
+        settings.BoardSize = boardSize;
+        await AppSettings.SaveAsync(JS, settings);
+        Nav.NavigateTo("");
+    }
+
+    private void Back()
+    {
+        Nav.NavigateTo("");
+    }
+}

--- a/Roulette/Pages/Preference.razor.css
+++ b/Roulette/Pages/Preference.razor.css
@@ -1,0 +1,4 @@
+.board-size-input {
+    text-align: right;
+    width: 6rem;
+}

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -21,6 +21,7 @@
     <label class="form-check-label" for="autoSize">大きさ自動調整</label>
 </div>
 
+
 <div class="mb-3 d-flex align-items-center">
     <label class="form-label me-2 mb-0">表示倍数</label>
     <input type="number" class="form-control multiplier-input" @bind="itemMultiplier" min="1" />

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -27,3 +27,4 @@
     text-align: right;
     width: 6rem;
 }
+


### PR DESCRIPTION
## Summary
- create new `AppSettings` model stored in `localStorage`
- introduce `Preference` page for global board size setting
- load board size from `AppSettings` on main page
- link to global preferences from manage and main pages
- remove `BoardSize` from per-config settings

## Testing
- `dotnet build Roulette/Roulette.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6889ca357450832c947096d67f3bdfe7