### PR TITLE
Implement manual size option

### DIFF
--- a/Roulette/Models/RouletteItem.cs
+++ b/Roulette/Models/RouletteItem.cs
@@ -10,6 +10,8 @@ public class RouletteItem
 
     public int Count { get; set; }
 
+    public double Size { get; set; } = 1;
+
     [JsonIgnore]
     public double Weight { get; set; } = 1;
 
@@ -20,7 +22,8 @@ public class RouletteItem
         return new RouletteItem
         {
             Text = text,
-            Color = RandomColor()
+            Color = RandomColor(),
+            Size = 1
         };
     }
 

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -205,21 +205,24 @@
 
     private void ApplyWeights()
     {
-        if (!autoAdjustSize)
+        if (items.Length == 0) return;
+
+        if (autoAdjustSize)
+        {
+            var min = items.Min(i => i.Count);
+            foreach (var item in items)
+            {
+                var count = item.Count;
+                item.Size = 1.0 / (count - min + 1);
+                item.Weight = item.Size;
+            }
+        }
+        else
         {
             foreach (var item in items)
             {
-                item.Weight = 1;
+                item.Weight = item.Size > 0 ? item.Size : 1;
             }
-            return;
-        }
-
-        if (items.Length == 0) return;
-        var min = items.Min(i => i.Count);
-        foreach (var item in items)
-        {
-            var count = item.Count;
-            item.Weight = 1.0 / (count - min + 1);
         }
     }
 

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -33,6 +33,10 @@
         <input type="color" class="form-control color-input" @bind="items[index].Color" />
         <input class="form-control text-input" @bind="items[index].Text" />
         <input type="number" class="form-control count-input" @bind="items[index].Count" />
+        @if (!autoAdjustSize)
+        {
+            <input type="number" step="0.1" class="form-control size-input" @bind="items[index].Size" />
+        }
         <button class="btn btn-outline-secondary" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
         <button class="btn btn-outline-secondary" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
         <button class="btn btn-outline-danger" @onclick="() => Remove(index)">削除</button>

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -23,6 +23,13 @@
     flex: unset;
 }
 
+.size-input {
+    text-align: right;
+    width: 4rem;
+    margin-left: 4px;
+    flex: unset;
+}
+
 .multiplier-input {
     text-align: right;
     width: 6rem;


### PR DESCRIPTION
## Summary
- track `Size` for roulette items
- allow manual item size when auto-adjust is disabled
- compute weights using stored sizes

## Testing
- `dotnet build Roulette.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688a381047e8832ca1ccfb23f454d118