### PR TITLE
Convert release date to browser time zone

### DIFF
--- a/Roulette/Pages/Manage.razor
+++ b/Roulette/Pages/Manage.razor
@@ -5,6 +5,7 @@
 @using System.Collections.Generic
 @using System.Linq
 @using System
+@using System.Globalization
 @using Roulette.Models
 
 <PageTitle>設定一覧 - ルーレット</PageTitle>
@@ -38,10 +39,20 @@ else
 }
 
 <div class="release-date">
-    更新日: <code>@Program.ReleaseDate</code>
+    更新日: <code>@LocalReleaseDate</code>
 </div>
 
 @code {
+    private static readonly string LocalReleaseDate =
+        DateTime.TryParseExact(
+            Program.ReleaseDate,
+            "yyyy/MM/dd HH:mm",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal,
+            out var utc)
+        ? utc.ToLocalTime().ToString("yyyy/MM/dd HH:mm")
+        : Program.ReleaseDate;
+
     [SupplyParameterFromQuery(Name = "url")]
     private string? Url { get; set; }
 


### PR DESCRIPTION
## Summary
- show release date in Manage page using the browser's local time zone

## Testing
- `dotnet build Roulette/Roulette.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_688aba5c99c8832c917b6b6c047b5d2c