### PR TITLE
Add validation alerts on settings save

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -120,11 +120,19 @@
     {
         if (string.IsNullOrWhiteSpace(configName))
         {
+            await JS.InvokeVoidAsync("alert", "設定名を入力してください。");
             return;
         }
+
         var arr = items
             .Where(x => !string.IsNullOrWhiteSpace(x.Text))
             .ToList();
+
+        if (arr.Count == 0 || arr.Count != items.Count)
+        {
+            await JS.InvokeVoidAsync("alert", "項目を1つ以上設定し、すべての項目名を入力してください。");
+            return;
+        }
 
         if (currentConfig is null)
         {

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -118,6 +118,7 @@
 
     private async Task Save()
     {
+        configName = configName.Trim();
         if (string.IsNullOrWhiteSpace(configName))
         {
             await JS.InvokeVoidAsync("alert", "設定名を入力してください。");


### PR DESCRIPTION
## Summary
- add validation in `Save` method on `Setting.razor`
- display alert if config name or item names are missing before saving

## Testing
- `dotnet build Roulette/Roulette.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688ac0002fe4832ca8fd29868b93e0d5