### PR TITLE
Trim item names when saving

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -125,6 +125,11 @@
             return;
         }
 
+        foreach (var item in items)
+        {
+            item.Text = item.Text.Trim();
+        }
+
         var arr = items
             .Where(x => !string.IsNullOrWhiteSpace(x.Text))
             .ToList();


### PR DESCRIPTION
## Summary
- trim `RouletteItem.Text` inside `Setting.Save`

## Testing
- `dotnet build Roulette/Roulette.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_688ad1f372ac832c85539fc5172312e6