### PR TITLE
Enable drag ordering in settings

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -29,7 +29,8 @@
 @for (int i = 0; i < items.Count; i++)
 {
     var index = i;
-    <div class="input-group mb-2 item-row">
+    <div class="input-group mb-2 item-row" @ondragover:preventDefault="true" @ondrop="(e) => OnDrop(index, e)">
+        <span class="input-group-text drag-handle" draggable="true" @ondragstart="(e) => OnDragStart(index, e)">☰</span>
         <input type="color" class="form-control color-input" @bind="items[index].Color" />
         <input class="form-control text-input" @bind="items[index].Text" />
         <input type="number" class="form-control count-input" @bind="items[index].Count" />
@@ -37,8 +38,6 @@
         {
             <input type="number" step="1" class="form-control size-input" @bind="items[index].Size" />
         }
-        <button class="btn btn-outline-secondary" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
-        <button class="btn btn-outline-secondary" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
         <button class="btn btn-outline-danger" @onclick="() => Remove(index)">削除</button>
     </div>
 }
@@ -65,6 +64,7 @@
     private RouletteConfig? currentConfig;
     private bool autoAdjustSize = true;
     private int itemMultiplier = 1;
+    private int? dragIndex;
 
     protected override async Task OnInitializedAsync()
     {
@@ -107,6 +107,22 @@
     private void MoveUp(int index) => MoveItem(index, -1);
 
     private void MoveDown(int index) => MoveItem(index, 1);
+
+    private void OnDragStart(int index, DragEventArgs e)
+    {
+        dragIndex = index;
+    }
+
+    private void OnDrop(int index, DragEventArgs e)
+    {
+        if (dragIndex is null || dragIndex == index) return;
+        var item = items[dragIndex.Value];
+        items.RemoveAt(dragIndex.Value);
+        if (dragIndex.Value < index) index--;
+        items.Insert(index, item);
+        dragIndex = null;
+    }
+
 
     private void ResetAllCounts()
     {

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -115,7 +115,7 @@
 
     private void MoveDown(int index) => MoveItem(index, 1);
 
-    private async Task OnDragStart(int index, DragEventArgs e)
+    private void OnDragStart(int index, DragEventArgs e)
     {
         dragIndex = index;
         if (e.DataTransfer is not null)
@@ -123,17 +123,11 @@
             e.DataTransfer.DropEffect = "move";
             e.DataTransfer.EffectAllowed = "move";
         }
-        await JS.InvokeVoidAsync("dragHelper.setDragData", e, index);
     }
 
-    private async Task OnDrop(int index, DragEventArgs e)
+    private void OnDrop(int index, DragEventArgs e)
     {
         int sourceIndex = dragIndex ?? -1;
-        if (await JS.InvokeAsync<string>("dragHelper.getDragData", e) is string s && int.TryParse(s, out var dtIndex))
-        {
-            sourceIndex = dtIndex;
-        }
-
         if (sourceIndex == -1 || sourceIndex == index) return;
 
         var item = items[sourceIndex];

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -108,17 +108,30 @@
 
     private void MoveDown(int index) => MoveItem(index, 1);
 
-    private void OnDragStart(int index, DragEventArgs e)
+    private async Task OnDragStart(int index, DragEventArgs e)
     {
         dragIndex = index;
+        if (e.DataTransfer is not null)
+        {
+            e.DataTransfer.DropEffect = "move";
+            e.DataTransfer.EffectAllowed = "move";
+        }
+        await JS.InvokeVoidAsync("dragHelper.setDragData", e, index);
     }
 
-    private void OnDrop(int index, DragEventArgs e)
+    private async Task OnDrop(int index, DragEventArgs e)
     {
-        if (dragIndex is null || dragIndex == index) return;
-        var item = items[dragIndex.Value];
-        items.RemoveAt(dragIndex.Value);
-        if (dragIndex.Value < index) index--;
+        int sourceIndex = dragIndex ?? -1;
+        if (await JS.InvokeAsync<string>("dragHelper.getDragData", e) is string s && int.TryParse(s, out var dtIndex))
+        {
+            sourceIndex = dtIndex;
+        }
+
+        if (sourceIndex == -1 || sourceIndex == index) return;
+
+        var item = items[sourceIndex];
+        items.RemoveAt(sourceIndex);
+        if (sourceIndex < index) index--;
         items.Insert(index, item);
         dragIndex = null;
     }

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -30,15 +30,22 @@
 {
     var index = i;
     <div class="input-group mb-2 item-row" @ondragover:preventDefault="true" @ondrop="(e) => OnDrop(index, e)">
-        <span class="input-group-text drag-handle" draggable="true" @ondragstart="(e) => OnDragStart(index, e)">☰</span>
-        <input type="color" class="form-control color-input" @bind="items[index].Color" />
-        <input class="form-control text-input" @bind="items[index].Text" />
-        <input type="number" class="form-control count-input" @bind="items[index].Count" />
+        <span class="input-group-text drag-handle" draggable="true"
+              @ondragstart="(e) => OnDragStart(index, e)"
+              @ondrop="(e) => OnDrop(index, e)" @ondragover:preventDefault="true">☰</span>
+        <input type="color" class="form-control color-input" @bind="items[index].Color"
+               @ondrop="(e) => OnDrop(index, e)" @ondragover:preventDefault="true" />
+        <input class="form-control text-input" @bind="items[index].Text"
+               @ondrop="(e) => OnDrop(index, e)" @ondragover:preventDefault="true" />
+        <input type="number" class="form-control count-input" @bind="items[index].Count"
+               @ondrop="(e) => OnDrop(index, e)" @ondragover:preventDefault="true" />
         @if (!autoAdjustSize)
         {
-            <input type="number" step="1" class="form-control size-input" @bind="items[index].Size" />
+            <input type="number" step="1" class="form-control size-input" @bind="items[index].Size"
+                   @ondrop="(e) => OnDrop(index, e)" @ondragover:preventDefault="true" />
         }
-        <button class="btn btn-outline-danger" @onclick="() => Remove(index)">削除</button>
+        <button class="btn btn-outline-danger" @onclick="() => Remove(index)"
+                @ondrop="(e) => OnDrop(index, e)" @ondragover:preventDefault="true">削除</button>
     </div>
 }
 

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -34,3 +34,8 @@
     text-align: right;
     width: 6rem;
 }
+
+.drag-handle {
+    cursor: move;
+    user-select: none;
+}

--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -261,18 +261,4 @@
             element?.click();
         } catch { }
     };
-
-    window.dragHelper = {
-        setDragData: function (e, index) {
-            try {
-                e.dataTransfer.setData('text/plain', index);
-                e.dataTransfer.effectAllowed = 'move';
-            } catch { }
-        },
-        getDragData: function (e) {
-            try {
-                return e.dataTransfer.getData('text/plain');
-            } catch { return null; }
-        }
-    };
 })();

--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -261,4 +261,18 @@
             element?.click();
         } catch { }
     };
+
+    window.dragHelper = {
+        setDragData: function (e, index) {
+            try {
+                e.dataTransfer.setData('text/plain', index);
+                e.dataTransfer.effectAllowed = 'move';
+            } catch { }
+        },
+        getDragData: function (e) {
+            try {
+                return e.dataTransfer.getData('text/plain');
+            } catch { return null; }
+        }
+    };
 })();


### PR DESCRIPTION
## Summary
- make item rows draggable on the settings page
- add CSS for a drag handle

## Testing
- `dotnet build Roulette.sln -c Release`
- `dotnet test Roulette.sln`

------
https://chatgpt.com/codex/tasks/task_e_688ad4ff8540832c9292efe118b833f1