### PR TITLE
Fix roulette wheel shadow

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -14,7 +14,9 @@
     <h4>@(string.IsNullOrEmpty(selectedConfig) ? "設定なし" : selectedConfig)</h4>
 </div>
 <div id="rouletteContainer" class="roulette-container">
-    <canvas id="rouletteCanvas" width="300" height="300" @onclick="ToggleSpin"></canvas>
+    <div class="wheel-shadow">
+        <canvas id="rouletteCanvas" width="300" height="300" @onclick="ToggleSpin"></canvas>
+    </div>
     <div class="pointer"></div>
     @if (showOverlay)
     {

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -3,7 +3,7 @@
     height: 300px;
     margin: 0 auto;
     border-radius: 50%;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    box-shadow: 3px 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 .wheel-shadow canvas {

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -1,12 +1,20 @@
-canvas {
-    display: block;
+.wheel-shadow {
+    width: 300px;
+    height: 300px;
     margin: 0 auto;
+    border-radius: 50%;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+.wheel-shadow canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
     touch-action: none;
     cursor: pointer;
     /* Limit pointer events to the circle so the cursor only changes on the wheel */
     clip-path: circle(50% at 50% 50%);
     border-radius: 50%;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     background: radial-gradient(circle at center, #fff 0%, #eee 100%);
 }
 


### PR DESCRIPTION
## Summary
- fix box-shadow being clipped by `clip-path`
- wrap the wheel `<canvas>` in a new element so the shadow displays

## Testing
- `dotnet build Roulette/Roulette.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688b6ecdd230832ca2459ae58d94f282