### PR TITLE
項目の三状態管理を追加

### DIFF
--- a/Roulette/Models/RouletteItem.cs
+++ b/Roulette/Models/RouletteItem.cs
@@ -12,6 +12,8 @@ public class RouletteItem
 
     public double Size { get; set; } = 1;
 
+    public RouletteItemState State { get; set; } = RouletteItemState.Locked;
+
     [JsonIgnore]
     public double Weight { get; set; } = 1;
 
@@ -23,7 +25,8 @@ public class RouletteItem
         {
             Text = text,
             Color = RandomColor(),
-            Size = 1
+            Size = 1,
+            State = RouletteItemState.Locked
         };
     }
 
@@ -53,4 +56,11 @@ public class RouletteItem
         int b = (int)Math.Round((b1 + m) * 255);
         return $"#{r:X2}{g:X2}{b:X2}";
     }
+}
+
+public enum RouletteItemState
+{
+    Enabled,
+    Locked,
+    Disabled
 }

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -36,6 +36,15 @@
         <label class="form-check-label" for="autoStopToggle">自動ストップ</label>
     </div>
 </div>
+
+@if (DisabledItemCount > 0)
+{
+    <div class="text-center mt-2">
+        <span>非表示数: @DisabledItemCount</span><br />
+        <button class="btn btn-secondary ms-2" @onclick="EnableAllDisabled">全て表示</button>
+    </div>
+}
+
 <div class="text-center mt-2">
     <h5 class="count-header" @onclick="ToggleCounts">当たり回数 @(showCounts ? "▲" : "▼")</h5>
     @if (showCounts)
@@ -62,13 +71,7 @@
         </table>
     }
 </div>
-<div class="text-center mt-2">
-    <span>無効項目数: @DisabledItemCount</span>
-    @if (DisabledItemCount > 0)
-    {
-        <button class="btn btn-secondary ms-2" @onclick="EnableAllDisabled">全て有効に戻す</button>
-    }
-</div>
+
 <div class="text-center mt-2">
     <button class="btn btn-secondary ms-2" @onclick="OpenManage">一覧</button>
     <button class="btn btn-secondary settings-button" @onclick="OpenSettings">設定</button>

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -63,6 +63,13 @@
     }
 </div>
 <div class="text-center mt-2">
+    <span>無効項目数: @DisabledItemCount</span>
+    @if (DisabledItemCount > 0)
+    {
+        <button class="btn btn-secondary ms-2" @onclick="EnableAllDisabled">全て有効に戻す</button>
+    }
+</div>
+<div class="text-center mt-2">
     <button class="btn btn-secondary ms-2" @onclick="OpenManage">一覧</button>
     <button class="btn btn-secondary settings-button" @onclick="OpenSettings">設定</button>
 </div>
@@ -88,6 +95,7 @@
     private string selectedConfig = string.Empty;
     private bool autoAdjustSize = true;
     private bool autoStop = true;
+    private int DisabledItemCount => allItems.Count(i => i.State == RouletteItemState.Disabled);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -156,6 +164,24 @@
     private void ToggleCounts()
     {
         showCounts = !showCounts;
+    }
+
+    private async Task EnableAllDisabled()
+    {
+        foreach (var item in allItems)
+        {
+            if (item.State == RouletteItemState.Disabled)
+            {
+                item.State = RouletteItemState.Enabled;
+            }
+        }
+        RebuildItems();
+        await SaveCountsAsync();
+        await JS.InvokeVoidAsync("rouletteHelper.initialize", "rouletteCanvas", ItemsForJs(), objRef);
+        var appSettings = await AppSettings.LoadAsync(JS);
+        await JS.InvokeVoidAsync("rouletteHelper.applySettings", appSettings);
+        await JS.InvokeVoidAsync("rouletteHelper.setAutoStopEnabled", autoStop);
+        StateHasChanged();
     }
 
     [JSInvokable]

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -48,7 +48,7 @@
                 </tr>
             </thead>
             <tbody>
-                @foreach (var item in items.Distinct())
+                @foreach (var item in allItems)
                 {
                     <tr>
                         <td>
@@ -72,13 +72,9 @@
     public string? Id { get; set; }
 
     private string? currentId;
-    private RouletteItem[] items = new[]
-    {
-        RouletteItem.Create("A"),
-        RouletteItem.Create("B"),
-        RouletteItem.Create("C"),
-        RouletteItem.Create("D")
-    };
+    private RouletteItem[] items = Array.Empty<RouletteItem>(); // active items
+    private RouletteItem[] allItems = Array.Empty<RouletteItem>();
+    private int itemMultiplier = 1;
     private bool isSpinning;
     private bool isStopping;
     private bool showOverlay;
@@ -113,23 +109,18 @@
                 return;
             }
 
-            var multiplier = cfg.ItemMultiplier <= 1 ? 1 : cfg.ItemMultiplier;
-            var list = new List<RouletteItem>(cfg.Items.Count * multiplier);
-            for (int i = 0; i < multiplier; i++)
-            {
-                list.AddRange(cfg.Items);
-            }
-            items = list.ToArray();
+            allItems = cfg.Items.ToArray();
+            itemMultiplier = cfg.ItemMultiplier;
             selectedConfig = cfg.Name;
             autoAdjustSize = cfg.AutoAdjustSize;
 
-            if (items.Length == 0 || items.All(i => string.IsNullOrWhiteSpace(i.Text)))
+            RebuildItems();
+
+            if (items.Length == 0 || allItems.All(i => string.IsNullOrWhiteSpace(i.Text)))
             {
                 Nav.NavigateTo($"setting/{Id}");
                 return;
             }
-
-            ApplyWeights();
 
             objRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("rouletteHelper.initialize", "rouletteCanvas", ItemsForJs(), objRef);
@@ -190,8 +181,16 @@
             if (!string.IsNullOrWhiteSpace(item.Text))
             {
                 item.Count++;
+                if (item.State == RouletteItemState.Enabled)
+                {
+                    item.State = RouletteItemState.Disabled;
+                    RebuildItems();
+                }
+                else
+                {
+                    ApplyWeights();
+                }
                 await SaveCountsAsync();
-                ApplyWeights();
             }
 
             StateHasChanged();
@@ -205,6 +204,19 @@
         isStopping = true;
         isSpinning = false;
         StateHasChanged();
+    }
+
+    private void RebuildItems()
+    {
+        var multiplier = itemMultiplier <= 1 ? 1 : itemMultiplier;
+        var active = allItems.Where(i => i.State != RouletteItemState.Disabled).ToList();
+        var list = new List<RouletteItem>(active.Count * multiplier);
+        for (int i = 0; i < multiplier; i++)
+        {
+            list.AddRange(active);
+        }
+        items = list.ToArray();
+        ApplyWeights();
     }
 
     private void ApplyWeights()
@@ -249,7 +261,7 @@
         var cfg = configs.FirstOrDefault(c => c.Id == Id);
         if (cfg is not null)
         {
-            cfg.Items = items.Distinct().ToList();
+            cfg.Items = allItems.ToList();
             await RouletteConfig.SaveAsync(JS, configs);
         }
     }

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -27,9 +27,10 @@
 </div>
 
 @for (int i = 0; i < items.Count; i++)
-{
+{ 
     var index = i;
     <div class="input-group mb-2 item-row">
+        <button class="btn btn-outline-secondary state-button" @onclick="() => ToggleState(index)" title="@GetStateTitle(items[index].State)">@GetStateIcon(items[index].State)</button>
         <input type="color" class="form-control color-input" @bind="items[index].Color" />
         <input class="form-control text-input" @bind="items[index].Text" />
         <input type="number" class="form-control count-input" @bind="items[index].Count" />
@@ -65,6 +66,33 @@
     private RouletteConfig? currentConfig;
     private bool autoAdjustSize = true;
     private int itemMultiplier = 1;
+
+    private void ToggleState(int index)
+    {
+        var item = items[index];
+        item.State = item.State switch
+        {
+            RouletteItemState.Locked => RouletteItemState.Enabled,
+            RouletteItemState.Enabled => RouletteItemState.Disabled,
+            _ => RouletteItemState.Locked
+        };
+    }
+
+    private static string GetStateIcon(RouletteItemState state) => state switch
+    {
+        RouletteItemState.Locked => "🔒",
+        RouletteItemState.Enabled => "✅",
+        RouletteItemState.Disabled => "🚫",
+        _ => string.Empty
+    };
+
+    private static string GetStateTitle(RouletteItemState state) => state switch
+    {
+        RouletteItemState.Locked => "有効（ロック）",
+        RouletteItemState.Enabled => "有効",
+        RouletteItemState.Disabled => "無効",
+        _ => string.Empty
+    };
 
     protected override async Task OnInitializedAsync()
     {

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -90,9 +90,9 @@
 
     private static string GetStateTitle(RouletteItemState state) => state switch
     {
-        RouletteItemState.Locked => "有効（ロック）",
-        RouletteItemState.Enabled => "有効",
-        RouletteItemState.Disabled => "無効",
+        RouletteItemState.Locked => "🔒表示",
+        RouletteItemState.Enabled => "表示",
+        RouletteItemState.Disabled => "非表示",
         _ => string.Empty
     };
 

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -27,20 +27,22 @@
 </div>
 
 @for (int i = 0; i < items.Count; i++)
-{ 
+{
     var index = i;
-    <div class="input-group mb-2 item-row">
-        <button class="btn btn-outline-secondary state-button" @onclick="() => ToggleState(index)" title="@GetStateTitle(items[index].State)">@GetStateIcon(items[index].State)</button>
+    <div class="mb-2 item-row">
         <input type="color" class="form-control color-input" @bind="items[index].Color" />
         <input class="form-control text-input" @bind="items[index].Text" />
-        <input type="number" class="form-control count-input" @bind="items[index].Count" />
-        @if (!autoAdjustSize)
-        {
-            <input type="number" step="1" class="form-control size-input" @bind="items[index].Size" />
-        }
-        <button class="btn btn-outline-secondary" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
-        <button class="btn btn-outline-secondary" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
-        <button class="btn btn-outline-danger" @onclick="() => Remove(index)">削除</button>
+        <button class="btn btn-outline-secondary move-up-button" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
+        <div class="control-row">
+            <button class="btn btn-outline-secondary state-button" @onclick="() => ToggleState(index)" title="@GetStateTitle(items[index].State)">@GetStateIcon(items[index].State)</button>
+            <input type="number" class="form-control count-input" @bind="items[index].Count" />
+            @if (!autoAdjustSize)
+            {
+                <input type="number" step="1" class="form-control size-input" @bind="items[index].Size" />
+            }
+            <button class="btn btn-outline-danger" @onclick="() => Remove(index)">削除</button>
+        </div>
+        <button class="btn btn-outline-secondary move-down-button" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
     </div>
 }
 

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -2,7 +2,7 @@
     display: grid;
     grid-template-columns: auto 1fr auto;
     grid-template-rows: auto auto;
-    gap: 4px;
+    gap: 0;
     align-items: center;
 }
 
@@ -42,13 +42,11 @@
 .count-input {
     text-align: right;
     width: 4rem;
-    margin-left: 4px;
 }
 
 .size-input {
     text-align: right;
     width: 4rem;
-    margin-left: 4px;
 }
 
 .multiplier-input {

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -1,33 +1,54 @@
 .item-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-rows: auto auto;
+    gap: 4px;
     align-items: center;
 }
 
-    .item-row .text-input {
-        flex: 1;
-        min-width: 0;
-    }
-
-.color-input {
+.item-row .color-input {
+    grid-row: span 2;
     width: 2.5rem;
-    height: 38px;
+    height: 100%;
     padding: 0;
-    flex: unset;
     cursor: pointer;
+    align-self: stretch;
+}
+
+.item-row .text-input {
+    grid-column: 2;
+    grid-row: 1;
+    width: 100%;
+    min-width: 0;
+}
+
+.item-row .move-up-button {
+    grid-column: 3;
+    grid-row: 1;
+}
+
+.item-row .move-down-button {
+    grid-column: 3;
+    grid-row: 2;
+}
+
+.item-row .control-row {
+    grid-column: 2;
+    grid-row: 2;
+    display: flex;
+    align-items: center;
 }
 
 .count-input {
     text-align: right;
     width: 4rem;
     margin-left: 4px;
-    flex: unset;
 }
 
 .size-input {
     text-align: right;
     width: 4rem;
     margin-left: 4px;
-    flex: unset;
 }
 
 .multiplier-input {


### PR DESCRIPTION
## 概要
- 項目の状態を「有効」「有効(ロック)」「無効」の3段階で管理
- 設定画面で状態を切り替えるボタンを追加
- 当選した有効項目を無効化し、ルーレット盤から除外

## テスト
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68922d40ef38832c97fd021957e6ecde