### PR TITLE
当たり回数一覧に項目状態を表示

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -62,6 +62,7 @@
                         <td>
                             <span class="color-box" style="background-color:@item.Color"></span>
                             @item.Text
+                            <span class="item-state" title="@GetStateTitle(item.State)">@GetStateIcon(item.State)</span>
                         </td>
                         <td class="text-end">@item.Count</td>
                     </tr>
@@ -293,6 +294,22 @@
             await RouletteConfig.SaveAsync(JS, configs);
         }
     }
+
+    private static string GetStateIcon(RouletteItemState state) => state switch
+    {
+        RouletteItemState.Locked => "🔒",
+        RouletteItemState.Enabled => "✅",
+        RouletteItemState.Disabled => "🚫",
+        _ => string.Empty
+    };
+
+    private static string GetStateTitle(RouletteItemState state) => state switch
+    {
+        RouletteItemState.Locked => "🔒表示",
+        RouletteItemState.Enabled => "表示",
+        RouletteItemState.Disabled => "非表示",
+        _ => string.Empty
+    };
 
     private static string GetContrastColor(string hex)
     {

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -108,3 +108,7 @@
     border: 1px solid rgba(0,0,0,0.2);
     border-radius: 2px;
 }
+
+.item-state {
+    margin-left: 4px;
+}


### PR DESCRIPTION
## 概要
- 当たり数一覧に表示・ロック・非表示の状態アイコンを追加
- 状態アイコン表示のためのヘルパーを実装
- アイコンのスタイルを調整

## テスト
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6892b3557208832c920ffb2be9bafa34