### PR TITLE
当たり回数リストの行背景を項目色に変更

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -59,14 +59,11 @@
             <tbody>
                 @foreach (var item in allItems)
                 {
-                    <tr>
+                    <tr style="background-color:@item.Color;color:@GetContrastColor(item.Color)">
                         <td class="text-start">
                             <span class="item-state" title="@GetStateTitle(item.State)">@GetStateIcon(item.State)</span>
-                            <span class="color-box" style="background-color:@item.Color"></span>
                         </td>
-                        <td>
-                            @item.Text
-                        </td>
+                        <td>@item.Text</td>
                         <td class="text-end">@item.Count</td>
                     </tr>
                 }

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -99,16 +99,6 @@
     user-select: none;
 }
 
-.color-box {
-    display: inline-block;
-    width: 12px;
-    height: 12px;
-    margin-right: 4px;
-    vertical-align: middle;
-    border: 1px solid rgba(0,0,0,0.2);
-    border-radius: 2px;
-}
-
 .item-state {
     margin-left: 4px;
 }


### PR DESCRIPTION
## 概要
- 当たり回数リストの行背景を各項目の色に変更
- 背景色に合わせて文字色を自動調整
- 余分になった color-box スタイルを削除

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68940e572f50832c87d81b0f0f0d0655