### PR TITLE
あたり回数リストの表示状態を設定ごとに保持

### DIFF
--- a/Roulette/Models/RouletteConfig.cs
+++ b/Roulette/Models/RouletteConfig.cs
@@ -17,6 +17,8 @@ public partial class RouletteConfig
 
     public int ItemMultiplier { get; set; } = 1;
 
+    public bool ShowCountList { get; set; } = false;
+
     [GeneratedRegex("^#[0-9A-Fa-f]{6}$")]
     private static partial Regex ColorRegex();
 
@@ -56,6 +58,11 @@ public partial class RouletteConfig
                         !el.TryGetProperty(nameof(ItemMultiplier), out _))
                     {
                         cfg.ItemMultiplier = 1;
+                    }
+                    if (!el.TryGetProperty("showCountList", out _) &&
+                        !el.TryGetProperty(nameof(ShowCountList), out _))
+                    {
+                        cfg.ShowCountList = false;
                     }
                     list.Add(cfg);
                 }

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -124,6 +124,7 @@
             itemMultiplier = cfg.ItemMultiplier;
             selectedConfig = cfg.Name;
             autoAdjustSize = cfg.AutoAdjustSize;
+            showCounts = cfg.ShowCountList;
 
             RebuildItems();
 
@@ -164,9 +165,10 @@
         await JS.InvokeVoidAsync("rouletteHelper.toggleSpin");
     }
 
-    private void ToggleCounts()
+    private async Task ToggleCounts()
     {
         showCounts = !showCounts;
+        await SaveCountsAsync();
     }
 
     private async Task EnableAllDisabled()
@@ -291,6 +293,7 @@
         if (cfg is not null)
         {
             cfg.Items = allItems.ToList();
+            cfg.ShowCountList = showCounts;
             await RouletteConfig.SaveAsync(JS, configs);
         }
     }

--- a/Roulette/Pages/Manage.razor
+++ b/Roulette/Pages/Manage.razor
@@ -82,7 +82,8 @@ else
             cfg.Name,
             cfg.Items,
             cfg.AutoAdjustSize,
-            cfg.ItemMultiplier
+            cfg.ItemMultiplier,
+            cfg.ShowCountList
         };
         var json = JsonSerializer.Serialize(exportObj, JsonUtil.WebOptions);
         var timestamp = DateTime.Now.ToString("yyyyMMddHHmmss");


### PR DESCRIPTION
## 概要
- RouletteConfigに当たり回数リストの表示状態を追加
- メイン画面で表示状態を読み書きして設定ごとに維持
- 設定を書き出す際にもこの情報を含める

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689436344364832cab8adf2a7f62f97c