### PR TITLE
当たり回数リストの枠線を改善

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -48,7 +48,7 @@
     <h5 class="count-header" @onclick="ToggleCounts">当たり回数リスト @(showCounts ? "▲" : "▼")</h5>
     @if (showCounts)
     {
-        <table class="table table-sm count-table" style="border-color:@borderColor;">
+        <table class="table table-sm count-table" style="--border-color:@borderColor;">
             <thead>
                 <tr>
                     <th>表示</th>
@@ -69,7 +69,7 @@
                 }
             </tbody>
         </table>
-    }
+        }
 </div>
 
 <div class="text-center mt-2">

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -92,7 +92,13 @@
 .count-table {
     margin: 0 auto 0.5rem auto;
     max-width: 300px;
-    border: solid 3px;
+    border: solid 3px var(--border-color);
+    border-collapse: collapse;
+}
+
+.count-table th,
+.count-table td {
+    border: solid 1px var(--border-color);
 }
 
 .count-header {


### PR DESCRIPTION
## 概要
- 当たり回数リストのテーブルに縦線を追加
- ヘッダの枠線色が他の部分と揃うよう修正

## テスト
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689438fb253c832caa6e765084f3abd3