### PR TITLE
あたり回数リストのヘッダ線の色を修正

### DIFF
--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -101,6 +101,10 @@
     border: solid 1px var(--border-color);
 }
 
+.count-table>:not(:last-child)>:last-child>* {
+    border-bottom-color: var(--border-color);
+}
+
 .count-header {
     cursor: pointer;
     user-select: none;


### PR DESCRIPTION
## 概要
- あたり回数リストのヘッダ行下線が黒く表示されていた問題を修正し、枠線色を統一

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6894453bdbdc832c842657345876ff09