### PR TITLE
ダブルタップによる拡大を禁止

### DIFF
--- a/Roulette/wwwroot/css/app.css
+++ b/Roulette/wwwroot/css/app.css
@@ -4,6 +4,7 @@ html, body {
     font-family: "BIZ UDPGothic", sans-serif;
     font-weight: 400;
     font-style: normal;
+    touch-action: manipulation;
 }
 
 h1:focus {

--- a/Roulette/wwwroot/index.html
+++ b/Roulette/wwwroot/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
     <title>ルーレット</title>
     <base href="/Roulette/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />


### PR DESCRIPTION
## 概要
- iPhoneなどでのダブルタップ拡大を無効化するためviewport設定とCSSを追加

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689b31bc12d8832cbe7a04352beaf3ba