### PR TITLE
ルーレット停止時のゆっくり回転を実装

### DIFF
--- a/Roulette/Models/AppSettings.cs
+++ b/Roulette/Models/AppSettings.cs
@@ -10,6 +10,7 @@ public class AppSettings
     public double StopDurationSeconds { get; set; } = 2.0;
     public double StartSpeed { get; set; } = 18.0;
     public string BorderColor { get; set; } = "#808080";
+    public bool IdleSpin { get; set; } = true;
 
     private const string StorageKey = "rouletteSettings";
 

--- a/Roulette/Pages/Env.razor
+++ b/Roulette/Pages/Env.razor
@@ -27,6 +27,10 @@
     <label class="form-label">ルーレット盤の枠線の色</label>
     <input type="color" class="form-control form-control-color" @bind="settings.BorderColor" />
 </div>
+<div class="mb-3 form-check form-switch">
+    <input class="form-check-input" type="checkbox" id="idleSpinToggle" @bind="settings.IdleSpin" />
+    <label class="form-check-label" for="idleSpinToggle">停止中も盤を回転させる</label>
+</div>
 
 <div class="mb-3 d-flex">
     <button class="btn btn-primary ms-auto" @onclick="Save">保存</button>

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -136,9 +136,9 @@
             }
 
             objRef ??= DotNetObjectReference.Create(this);
-            await JS.InvokeVoidAsync("rouletteHelper.initialize", "rouletteCanvas", ItemsForJs(), objRef);
             var appSettings = await AppSettings.LoadAsync(JS);
             borderColor = appSettings.BorderColor;
+            await JS.InvokeVoidAsync("rouletteHelper.initialize", "rouletteCanvas", ItemsForJs(), objRef, appSettings.IdleSpin);
             await JS.InvokeVoidAsync("rouletteHelper.applySettings", appSettings);
             await JS.InvokeVoidAsync("rouletteHelper.setAutoStopEnabled", autoStop);
 
@@ -184,8 +184,8 @@
         }
         RebuildItems();
         await SaveCountsAsync();
-        await JS.InvokeVoidAsync("rouletteHelper.initialize", "rouletteCanvas", ItemsForJs(), objRef);
         var appSettings = await AppSettings.LoadAsync(JS);
+        await JS.InvokeVoidAsync("rouletteHelper.initialize", "rouletteCanvas", ItemsForJs(), objRef, appSettings.IdleSpin);
         await JS.InvokeVoidAsync("rouletteHelper.applySettings", appSettings);
         await JS.InvokeVoidAsync("rouletteHelper.setAutoStopEnabled", autoStop);
         StateHasChanged();
@@ -278,8 +278,8 @@
     private async void HideOverlay()
     {
         showOverlay = false;
-        await JS.InvokeVoidAsync("rouletteHelper.initialize", "rouletteCanvas", ItemsForJs(), objRef);
         var appSettings = await AppSettings.LoadAsync(JS);
+        await JS.InvokeVoidAsync("rouletteHelper.initialize", "rouletteCanvas", ItemsForJs(), objRef, appSettings.IdleSpin);
         await JS.InvokeVoidAsync("rouletteHelper.applySettings", appSettings);
     }
 

--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -8,7 +8,10 @@
     }
     let canvas, ctx, items = [], angle = 0, angleMap = [];
     let spinning = false;
+    let idle = false;
+    const idleSpeed = 0.2; // slow rotation when idle
     let speed = 0; // angular velocity in radians per second
+    let animationId = null; // requestAnimationFrame id
     let lastTime = null; // timestamp of previous frame for consistent timing
     let autoStopTimeout = null;
     let autoStopEnabled = true;
@@ -121,8 +124,10 @@
         const delta = (timestamp - lastTime) / 1000; // seconds since last frame
         lastTime = timestamp;
 
-        angle += speed * delta;
-        if (!spinning) {
+        if (spinning) {
+            angle += speed * delta;
+        } else if (speed > 0) {
+            angle += speed * delta;
             if (stopStartTime === null) {
                 stopStartTime = timestamp;
                 stopInitialSpeed = speed;
@@ -138,14 +143,21 @@
                 }
                 lastTime = null;
                 stopStartTime = null;
+                animationId = null;
                 return;
             } else {
                 const eased = Math.pow(1 - progress, 2);
                 speed = stopInitialSpeed * eased;
             }
+        } else if (idle) {
+            angle += idleSpeed * delta;
+        } else {
+            draw();
+            animationId = null;
+            return;
         }
         draw();
-        requestAnimationFrame(tick);
+        animationId = requestAnimationFrame(tick);
     }
 
     function getCurrentIndex() {
@@ -161,6 +173,13 @@
     }
 
     window.rouletteHelper = window.rouletteHelper || {};
+
+    function ensureTick() {
+        if (animationId === null) {
+            lastTime = null;
+            animationId = requestAnimationFrame(tick);
+        }
+    }
 
     function removeSwipeHandlers() {
         if (!canvas) return;
@@ -215,6 +234,8 @@
         computeAngles();
         draw();
         addSwipeHandlers();
+        idle = true;
+        ensureTick();
     };
 
     window.rouletteHelper.setItems = function (itemsArr) {
@@ -223,6 +244,7 @@
         if (!spinning) {
             draw();
         }
+        if (idle) ensureTick();
     };
 
     window.rouletteHelper.setAutoStopEnabled = function (value) {
@@ -242,11 +264,13 @@
         if (typeof settings.stopDurationSeconds === 'number') stopDurationMs = settings.stopDurationSeconds * 1000;
         if (typeof settings.borderColor === 'string') borderColor = settings.borderColor;
         if (!spinning) draw();
+        if (idle) ensureTick();
     };
 
     window.rouletteHelper.toggleSpin = function () {
         if (spinning) {
             spinning = false;
+            idle = false;
             tryVibrate(50);
             if (autoStopTimeout) {
                 clearTimeout(autoStopTimeout);
@@ -254,10 +278,11 @@
             }
         } else {
             spinning = true;
+            idle = false;
             speed = startSpeedSetting;
             stopStartTime = null;
             lastTime = null;
-            requestAnimationFrame(tick);
+            ensureTick();
             tryVibrate(50);
             if (autoStopTimeout) {
                 clearTimeout(autoStopTimeout);
@@ -270,6 +295,7 @@
                             dotNetHelper.invokeMethodAsync('OnAutoStop');
                         }
                         spinning = false;
+                        idle = false;
                         tryVibrate(50);
                     }
                 }, delay);

--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -212,7 +212,7 @@
         canvas.addEventListener('pointerup', onPointerUp);
     }
 
-    window.rouletteHelper.initialize = function (id, itemsArr, dotNetRef) {
+    window.rouletteHelper.initialize = function (id, itemsArr, dotNetRef, idleSpin = true) {
         removeSwipeHandlers();
         canvas = document.getElementById(id);
         if (!canvas) return;
@@ -234,8 +234,8 @@
         computeAngles();
         draw();
         addSwipeHandlers();
-        idle = true;
-        ensureTick();
+        idle = !!idleSpin;
+        if (idle) ensureTick();
     };
 
     window.rouletteHelper.setItems = function (itemsArr) {
@@ -263,6 +263,7 @@
         if (autoStopMaxMs < autoStopMinMs) autoStopMaxMs = autoStopMinMs;
         if (typeof settings.stopDurationSeconds === 'number') stopDurationMs = settings.stopDurationSeconds * 1000;
         if (typeof settings.borderColor === 'string') borderColor = settings.borderColor;
+        if (typeof settings.idleSpin === 'boolean') idle = settings.idleSpin;
         if (!spinning) draw();
         if (idle) ensureTick();
     };

--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -9,7 +9,7 @@
     let canvas, ctx, items = [], angle = 0, angleMap = [];
     let spinning = false;
     let idle = false;
-    const idleSpeed = 0.2; // slow rotation when idle
+    const idleSpeed = 0.12; // slow rotation when idle
     let speed = 0; // angular velocity in radians per second
     let animationId = null; // requestAnimationFrame id
     let lastTime = null; // timestamp of previous frame for consistent timing


### PR DESCRIPTION
## 概要
- ルーレットが停止中に低速で回り続ける挙動を追加
- スタート前と結果ポップアップ閉鎖後に自動でアイドル回転を開始
- トグル操作や設定反映時の処理を整理

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a10e6b1e08832c993905c8a746d410