### PR TITLE
回転中の画面遷移でおかしくなる問題を修正

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -336,6 +336,7 @@
 
     public void Dispose()
     {
+        _ = JS.InvokeVoidAsync("rouletteHelper.dispose");
         objRef?.Dispose();
     }
 

--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -304,6 +304,24 @@
         }
     };
 
+    window.rouletteHelper.dispose = function () {
+        spinning = false;
+        idle = false;
+        if (animationId !== null) {
+            cancelAnimationFrame(animationId);
+            animationId = null;
+        }
+        if (autoStopTimeout) {
+            clearTimeout(autoStopTimeout);
+            autoStopTimeout = null;
+        }
+        removeSwipeHandlers();
+        canvas = null;
+        ctx = null;
+        items = [];
+        dotNetHelper = null;
+    };
+
     window.rouletteHelper.getContainerCenter = function (id) {
         try {
             const el = document.getElementById(id);


### PR DESCRIPTION
## 概要
- ルーレット回転中に別ページへ遷移した際の不具合を修正
- JS 側に `dispose` を実装し、ページ破棄時に後始末を実施

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a114125f7c832cbd9a797ddaa2c681