### PR TITLE
自動ストップの最大時間設定を廃止し1周以内で停止するよう変更

### DIFF
--- a/Roulette/Models/AppSettings.cs
+++ b/Roulette/Models/AppSettings.cs
@@ -6,7 +6,6 @@ namespace Roulette.Models;
 public class AppSettings
 {
     public double AutoStopDelayMinSeconds { get; set; } = 2.0;
-    public double AutoStopDelayMaxSeconds { get; set; } = 3.0;
     public double StopDurationSeconds { get; set; } = 2.0;
     public double StartSpeed { get; set; } = 18.0;
     public string BorderColor { get; set; } = "#808080";

--- a/Roulette/Pages/Env.razor
+++ b/Roulette/Pages/Env.razor
@@ -8,12 +8,12 @@
 <h3>環境設定</h3>
 
 <div class="mb-3">
-    <label class="form-label">止まり始めるまでの最小時間 (秒)</label>
+    <label class="form-label">減速開始までの最小時間 (秒)</label>
     <input type="number" step="0.1" min="0" class="form-control" @bind="settings.AutoStopDelayMinSeconds" />
-    <div class="form-text">この時間経過後に1周未満のランダムな時間回転したのち減速します。</div>
+    <div class="form-text">この時間経過後に、1周未満のランダムな時間回転したのち、減速を開始します。</div>
 </div>
 <div class="mb-3">
-    <label class="form-label">止まり始めてから完全に止まるまでの時間 (秒)</label>
+    <label class="form-label">減速開始から完全に止まるまでの時間 (秒)</label>
     <input type="number" step="0.1" min="0.1" class="form-control" @bind="settings.StopDurationSeconds" />
 </div>
 <div class="mb-3">

--- a/Roulette/Pages/Env.razor
+++ b/Roulette/Pages/Env.razor
@@ -12,10 +12,6 @@
     <input type="number" step="0.1" min="0" class="form-control" @bind="settings.AutoStopDelayMinSeconds" />
 </div>
 <div class="mb-3">
-    <label class="form-label">止まり始めるまでの最大時間 (秒)</label>
-    <input type="number" step="0.1" min="0" class="form-control" @bind="settings.AutoStopDelayMaxSeconds" />
-</div>
-<div class="mb-3">
     <label class="form-label">止まり始めてから完全に止まるまでの時間 (秒)</label>
     <input type="number" step="0.1" min="0.1" class="form-control" @bind="settings.StopDurationSeconds" />
 </div>
@@ -47,10 +43,6 @@
 
     private async Task Save()
     {
-        if (settings.AutoStopDelayMaxSeconds < settings.AutoStopDelayMinSeconds)
-        {
-            settings.AutoStopDelayMaxSeconds = settings.AutoStopDelayMinSeconds;
-        }
         await AppSettings.SaveAsync(JS, settings);
         Nav.NavigateTo("");
     }

--- a/Roulette/Pages/Env.razor
+++ b/Roulette/Pages/Env.razor
@@ -10,6 +10,7 @@
 <div class="mb-3">
     <label class="form-label">止まり始めるまでの最小時間 (秒)</label>
     <input type="number" step="0.1" min="0" class="form-control" @bind="settings.AutoStopDelayMinSeconds" />
+    <div class="form-text">この時間経過後に1周未満のランダムな時間回転したのち減速します。</div>
 </div>
 <div class="mb-3">
     <label class="form-label">止まり始めてから完全に止まるまでの時間 (秒)</label>

--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -17,7 +17,6 @@
     let autoStopEnabled = true;
     let startSpeedSetting = 18;
     let autoStopMinMs = 2000;
-    let autoStopMaxMs = 3000;
     let stopDurationMs = 2000;
     let borderColor = '#808080';
     let stopStartTime = null;
@@ -259,8 +258,6 @@
         if (!settings) return;
         if (typeof settings.startSpeed === 'number') startSpeedSetting = settings.startSpeed;
         if (typeof settings.autoStopDelayMinSeconds === 'number') autoStopMinMs = settings.autoStopDelayMinSeconds * 1000;
-        if (typeof settings.autoStopDelayMaxSeconds === 'number') autoStopMaxMs = settings.autoStopDelayMaxSeconds * 1000;
-        if (autoStopMaxMs < autoStopMinMs) autoStopMaxMs = autoStopMinMs;
         if (typeof settings.stopDurationSeconds === 'number') stopDurationMs = settings.stopDurationSeconds * 1000;
         if (typeof settings.borderColor === 'string') borderColor = settings.borderColor;
         if (typeof settings.idleSpin === 'boolean') idle = settings.idleSpin;
@@ -289,7 +286,8 @@
                 clearTimeout(autoStopTimeout);
             }
             if (autoStopEnabled) {
-                const delay = autoStopMinMs + Math.random() * (autoStopMaxMs - autoStopMinMs);
+                const rotationMs = startSpeedSetting > 0 ? 2 * Math.PI / startSpeedSetting * 1000 : 0;
+                const delay = autoStopMinMs + Math.random() * rotationMs;
                 autoStopTimeout = setTimeout(function () {
                     if (spinning) {
                         if (dotNetHelper) {


### PR DESCRIPTION
## 概要
- 自動ストップ設定から最大時間を削除
- 最小時間経過後、1周以内のランダムなタイミングで停止開始するようJSを更新
- 設定ページから最大時間入力欄と関連処理を削除

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a1b58d5ec0832c894562dfc2e9de0a