### PR TITLE
長い項目名の表示を自動縮小

### DIFF
--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -68,8 +68,17 @@
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillStyle = getContrastColor(color);
-        ctx.font = "16px 'BIZ UDPGothic', sans-serif";
         const text = item?.text || item;
+        const baseSize = 16;
+        const angle = end - start;
+        const maxWidth = 2 * textMid * Math.sin(angle / 2) * 0.9;
+        ctx.font = `${baseSize}px 'BIZ UDPGothic', sans-serif`;
+        const metrics = ctx.measureText(text);
+        let fontSize = baseSize;
+        if (metrics.width > maxWidth) {
+            fontSize = Math.max(6, Math.floor(baseSize * maxWidth / metrics.width));
+            ctx.font = `${fontSize}px 'BIZ UDPGothic', sans-serif`;
+        }
         ctx.fillText(text, textMid, 0);
         ctx.restore();
     }


### PR DESCRIPTION
## 概要
- ルーレット盤の各項目名を幅に合わせて縮小

## テスト
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a1c448788c832ca7d9a857da167ba2