### PR TITLE
フォント自動調整のオン/オフ設定を追加

### DIFF
--- a/Roulette/Models/AppSettings.cs
+++ b/Roulette/Models/AppSettings.cs
@@ -10,6 +10,7 @@ public class AppSettings
     public double StartSpeed { get; set; } = 18.0;
     public string BorderColor { get; set; } = "#808080";
     public bool IdleSpin { get; set; } = true;
+    public bool AutoFontSize { get; set; } = true;
 
     private const string StorageKey = "rouletteSettings";
 

--- a/Roulette/Pages/Env.razor
+++ b/Roulette/Pages/Env.razor
@@ -28,6 +28,10 @@
     <input class="form-check-input" type="checkbox" id="idleSpinToggle" @bind="settings.IdleSpin" />
     <label class="form-check-label" for="idleSpinToggle">停止中も盤を回転させる</label>
 </div>
+<div class="mb-3 form-check form-switch">
+    <input class="form-check-input" type="checkbox" id="autoFontToggle" @bind="settings.AutoFontSize" />
+    <label class="form-check-label" for="autoFontToggle">項目の文字量に応じてフォントサイズを自動調整する</label>
+</div>
 
 <div class="mb-3 d-flex">
     <button class="btn btn-primary ms-auto" @onclick="Save">保存</button>

--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -19,6 +19,7 @@
     let autoStopMinMs = 2000;
     let stopDurationMs = 2000;
     let borderColor = '#808080';
+    let autoFontSize = true;
     let stopStartTime = null;
     let stopInitialSpeed = 0;
     let dotNetHelper = null;
@@ -71,12 +72,14 @@
         const text = item?.text || item;
         const baseSize = 16;
         const maxWidth = 2 * textMid * 0.7;
-        ctx.font = `${baseSize}px 'BIZ UDPGothic', sans-serif`;
-        const metrics = ctx.measureText(text);
         let fontSize = baseSize;
-        if (metrics.width > maxWidth) {
-            fontSize = Math.max(6, Math.floor(baseSize * maxWidth / metrics.width));
-            ctx.font = `${fontSize}px 'BIZ UDPGothic', sans-serif`;
+        ctx.font = `${fontSize}px 'BIZ UDPGothic', sans-serif`;
+        if (autoFontSize) {
+            const metrics = ctx.measureText(text);
+            if (metrics.width > maxWidth) {
+                fontSize = Math.max(6, Math.floor(baseSize * maxWidth / metrics.width));
+                ctx.font = `${fontSize}px 'BIZ UDPGothic', sans-serif`;
+            }
         }
         ctx.fillText(text, textMid, 0);
         ctx.restore();
@@ -269,6 +272,7 @@
         if (typeof settings.stopDurationSeconds === 'number') stopDurationMs = settings.stopDurationSeconds * 1000;
         if (typeof settings.borderColor === 'string') borderColor = settings.borderColor;
         if (typeof settings.idleSpin === 'boolean') idle = settings.idleSpin;
+        if (typeof settings.autoFontSize === 'boolean') autoFontSize = settings.autoFontSize;
         if (!spinning) draw();
         if (idle) ensureTick();
     };


### PR DESCRIPTION
## 概要
- 項目の文字量に応じたフォントサイズ自動調整を環境設定で切り替え可能に
- AppSettings と JavaScript を更新して設定を反映

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a1d6d22d84832cbbc1cc5d4dbe21c9