### PR TITLE
色自動割り当て機能の追加

### DIFF
--- a/Roulette/Pages/Color.razor
+++ b/Roulette/Pages/Color.razor
@@ -1,0 +1,141 @@
+@page "/color/{Id?}"
+@inject IJSRuntime JS
+@inject NavigationManager Nav
+@using System.Text.Json
+@using System.Collections.Generic
+@using System.Linq
+@using Roulette.Models
+
+<PageTitle>色自動割り当て - ルーレット</PageTitle>
+
+<h3>項目の色自動割り当て</h3>
+
+<div class="mb-3 d-flex align-items-center">
+    <label class="form-label me-2 mb-0">明度</label>
+    <input type="number" class="form-control w-auto" @bind="lightness" min="0" max="1" step="0.01" />
+</div>
+
+<div class="mb-3 d-flex align-items-center">
+    <label class="form-label me-2 mb-0">彩度</label>
+    <input type="number" class="form-control w-auto" @bind="chroma" min="0" max="0.4" step="0.01" />
+</div>
+
+<div class="mb-3 d-flex">
+    <button class="btn btn-primary" @onclick="AssignEven">均等に割り当て</button>
+    <button class="btn btn-secondary ms-2" @onclick="AssignRandom">ランダムに割り当て</button>
+    <button class="btn btn-outline-secondary ms-auto" @onclick="Back">戻る</button>
+</div>
+
+@code {
+    [Parameter]
+    public string? Id { get; set; }
+
+    private List<RouletteItem> items = new();
+    private List<RouletteConfig> configs = new();
+    private RouletteConfig? currentConfig;
+
+    private double lightness = 0.8;
+    private double chroma = 0.1;
+    private readonly Random rand = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        configs = await RouletteConfig.LoadAsync(JS);
+
+        if (!string.IsNullOrEmpty(Id))
+        {
+            currentConfig = configs.FirstOrDefault(c => c.Id == Id);
+            if (currentConfig is not null)
+            {
+                items = currentConfig.Items.ToList();
+            }
+        }
+        else
+        {
+            var json = await JS.InvokeAsync<string?>("localStorage.getItem", "rouletteItems");
+            if (!string.IsNullOrEmpty(json))
+            {
+                items = JsonSerializer.Deserialize<List<RouletteItem>>(json, JsonUtil.WebOptions) ?? new();
+            }
+        }
+    }
+
+    private async Task AssignEven()
+    {
+        if (items.Count == 0) return;
+        for (int i = 0; i < items.Count; i++)
+        {
+            var hue = 360.0 * i / items.Count;
+            items[i].Color = OklchToHex(lightness, chroma, hue);
+        }
+        await SaveAsync();
+        Back();
+    }
+
+    private async Task AssignRandom()
+    {
+        if (items.Count == 0) return;
+        foreach (var item in items)
+        {
+            var hue = rand.NextDouble() * 360.0;
+            item.Color = OklchToHex(lightness, chroma, hue);
+        }
+        await SaveAsync();
+        Back();
+    }
+
+    private async Task SaveAsync()
+    {
+        if (currentConfig is not null)
+        {
+            currentConfig.Items = items;
+            await RouletteConfig.SaveAsync(JS, configs);
+        }
+        else
+        {
+            var json = JsonSerializer.Serialize(items, JsonUtil.WebOptions);
+            await JS.InvokeVoidAsync("localStorage.setItem", "rouletteItems", json);
+        }
+    }
+
+    private void Back()
+    {
+        if (string.IsNullOrEmpty(Id))
+        {
+            Nav.NavigateTo("setting");
+        }
+        else
+        {
+            Nav.NavigateTo($"setting/{Id}");
+        }
+    }
+
+    private static string OklchToHex(double l, double c, double h)
+    {
+        var hr = Math.PI * h / 180.0;
+        var a = Math.Cos(hr) * c;
+        var b = Math.Sin(hr) * c;
+
+        var l_ = l + 0.3963377774 * a + 0.2158037573 * b;
+        var m_ = l - 0.1055613458 * a - 0.0638541728 * b;
+        var s_ = l - 0.0894841775 * a - 1.2914855480 * b;
+
+        var l3 = l_ * l_ * l_;
+        var m3 = m_ * m_ * m_;
+        var s3 = s_ * s_ * s_;
+
+        var r = +4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3;
+        var g = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3;
+        var b2 = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.7076147010 * s3;
+
+        double srgb(double x) => x <= 0.0031308 ? 12.92 * x : 1.055 * Math.Pow(x, 1.0 / 2.4) - 0.055;
+
+        var rr = srgb(r);
+        var gg = srgb(g);
+        var bb = srgb(b2);
+
+        int clamp(double v) => (int)Math.Round(Math.Clamp(v, 0, 1) * 255);
+
+        return $"#{clamp(rr):X2}{clamp(gg):X2}{clamp(bb):X2}";
+    }
+}

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -56,6 +56,10 @@
     <button class="btn btn-secondary ms-2" @onclick="Back">戻る</button>
 </div>
 
+<div class="mb-3">
+    <button class="btn btn-secondary" @onclick="OpenColorAuto">色自動割り当て</button>
+</div>
+
 @code {
     [Parameter]
     public string? Id { get; set; }
@@ -146,6 +150,18 @@
         foreach (var item in items)
         {
             item.Count = 0;
+        }
+    }
+
+    private void OpenColorAuto()
+    {
+        if (string.IsNullOrEmpty(Id))
+        {
+            Nav.NavigateTo("color");
+        }
+        else
+        {
+            Nav.NavigateTo($"color/{Id}");
         }
     }
 


### PR DESCRIPTION
## 概要
- 項目の色を自動割り当てするページを追加
- 設定画面から自動割り当てページを開くボタンを設置

## 動作確認
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a1f7e4879c832c9bb9ff4b190c7dcf