### PR TITLE
新規項目追加時に直前の表示状態を引き継ぐよう修正

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -119,7 +119,14 @@
 
     private void Add()
     {
-        items.Add(RouletteItem.Create());
+        var item = RouletteItem.Create();
+
+        if (items.Count > 0)
+        {
+            item.State = items[items.Count - 1].State;
+        }
+
+        items.Add(item);
     }
 
     private void Remove(int index)


### PR DESCRIPTION
## 概要
- 追加ボタン押下で新規項目を作成する際、直前の項目の表示状態を引き継ぐように変更
- 既存項目が無い場合は従来どおりロック状態で追加

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a2593b952c832c891abe252a12b9bd