### PR TITLE
OKLCH色変換の共通化と項目追加時の色設定改善

### DIFF
--- a/Roulette/Models/ColorUtil.cs
+++ b/Roulette/Models/ColorUtil.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Roulette.Models;
+
+public static class ColorUtil
+{
+    public static string OklchToHex(double l, double c, double h)
+    {
+        var hr = Math.PI * h / 180.0;
+        var a = Math.Cos(hr) * c;
+        var b = Math.Sin(hr) * c;
+
+        var l_ = l + 0.3963377774 * a + 0.2158037573 * b;
+        var m_ = l - 0.1055613458 * a - 0.0638541728 * b;
+        var s_ = l - 0.0894841775 * a - 1.2914855480 * b;
+
+        var l3 = l_ * l_ * l_;
+        var m3 = m_ * m_ * m_;
+        var s3 = s_ * s_ * s_;
+
+        var r = +4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3;
+        var g = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3;
+        var b2 = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.7076147010 * s3;
+
+        double srgb(double x) => x <= 0.0031308 ? 12.92 * x : 1.055 * Math.Pow(x, 1.0 / 2.4) - 0.055;
+
+        var rr = srgb(r);
+        var gg = srgb(g);
+        var bb = srgb(b2);
+
+        int clamp(double v) => (int)Math.Round(Math.Clamp(v, 0, 1) * 255);
+
+        return $"#{clamp(rr):X2}{clamp(gg):X2}{clamp(bb):X2}";
+    }
+
+    public static (double l, double c, double h) HexToOklch(string hex)
+    {
+        if (string.IsNullOrWhiteSpace(hex)) return (0.8, 0.1, 0);
+        if (hex.StartsWith('#')) hex = hex[1..];
+        if (hex.Length != 6) return (0.8, 0.1, 0);
+
+        var r = Convert.ToInt32(hex.Substring(0, 2), 16) / 255.0;
+        var g = Convert.ToInt32(hex.Substring(2, 2), 16) / 255.0;
+        var b = Convert.ToInt32(hex.Substring(4, 2), 16) / 255.0;
+
+        double lin(double x) => x <= 0.04045 ? x / 12.92 : Math.Pow((x + 0.055) / 1.055, 2.4);
+        r = lin(r); g = lin(g); b = lin(b);
+
+        var l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+        var m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+        var s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+
+        var l_ = Math.Cbrt(l);
+        var m_ = Math.Cbrt(m);
+        var s_ = Math.Cbrt(s);
+
+        var L = 0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_;
+        var a = 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_;
+        var b2 = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_;
+
+        var C = Math.Sqrt(a * a + b2 * b2);
+        var H = Math.Atan2(b2, a) * 180.0 / Math.PI;
+        if (H < 0) H += 360.0;
+
+        return (L, C, H);
+    }
+}
+

--- a/Roulette/Models/RouletteConfig.cs
+++ b/Roulette/Models/RouletteConfig.cs
@@ -26,12 +26,14 @@ public partial class RouletteConfig
     {
         foreach (var cfg in configs)
         {
+            string? prevColor = null;
             foreach (var item in cfg.Items)
             {
                 if (string.IsNullOrWhiteSpace(item.Color) || !ColorRegex().IsMatch(item.Color))
                 {
-                    item.Color = RouletteItem.RandomColor();
+                    item.Color = RouletteItem.RandomColor(prevColor);
                 }
+                prevColor = item.Color;
             }
         }
     }

--- a/Roulette/Models/RouletteItem.cs
+++ b/Roulette/Models/RouletteItem.cs
@@ -19,42 +19,29 @@ public class RouletteItem
 
     private static readonly Random s_rand = new();
 
-    public static RouletteItem Create(string text = "")
+    public static RouletteItem Create(string text = "", string? baseColor = null)
     {
         return new RouletteItem
         {
             Text = text,
-            Color = RandomColor(),
+            Color = RandomColor(baseColor),
             Size = 1,
             State = RouletteItemState.Locked
         };
     }
 
-    public static string RandomColor()
+    public static string RandomColor(string? baseColor = null)
     {
-        // Choose colors with good readability
-        var hue = s_rand.NextDouble() * 360;            // 0 - 360
-        var saturation = 0.6 + s_rand.NextDouble() * 0.3; // 60% - 90%
-        var lightness = 0.5 + s_rand.NextDouble() * 0.2;  // 50% - 70%
-        return HslToHex(hue, saturation, lightness);
-    }
-
-    private static string HslToHex(double h, double s, double l)
-    {
-        double c = (1 - Math.Abs(2 * l - 1)) * s;
-        double x = c * (1 - Math.Abs((h / 60) % 2 - 1));
-        double m = l - c / 2;
-        double r1, g1, b1;
-        if (h < 60) { r1 = c; g1 = x; b1 = 0; }
-        else if (h < 120) { r1 = x; g1 = c; b1 = 0; }
-        else if (h < 180) { r1 = 0; g1 = c; b1 = x; }
-        else if (h < 240) { r1 = 0; g1 = x; b1 = c; }
-        else if (h < 300) { r1 = x; g1 = 0; b1 = c; }
-        else { r1 = c; g1 = 0; b1 = x; }
-        int r = (int)Math.Round((r1 + m) * 255);
-        int g = (int)Math.Round((g1 + m) * 255);
-        int b = (int)Math.Round((b1 + m) * 255);
-        return $"#{r:X2}{g:X2}{b:X2}";
+        double l = 0.95;
+        double c = 0.02;
+        if (!string.IsNullOrWhiteSpace(baseColor))
+        {
+            var (l0, c0, _) = ColorUtil.HexToOklch(baseColor);
+            l = l0;
+            c = c0;
+        }
+        var h = s_rand.NextDouble() * 360;
+        return ColorUtil.OklchToHex(l, c, h);
     }
 }
 

--- a/Roulette/Pages/Color.razor
+++ b/Roulette/Pages/Color.razor
@@ -92,7 +92,7 @@
         }
         if (items.Count > 0)
         {
-            var (l, c, _) = HexToOklch(items[^1].Color);
+            var (l, c, _) = ColorUtil.HexToOklch(items[^1].Color);
             _lightness = Math.Clamp(l, 0, 1);
             _chroma = Math.Clamp(c, 0, 0.4);
         }
@@ -106,7 +106,7 @@
         for (int i = 0; i < items.Count; i++)
         {
             var hue = 360.0 * i / items.Count;
-            items[i].Color = OklchToHex(lightness, chroma, hue);
+            items[i].Color = ColorUtil.OklchToHex(lightness, chroma, hue);
         }
         await SaveAsync();
         Back();
@@ -128,7 +128,7 @@
 
         for (int i = 0; i < items.Count; i++)
         {
-            items[i].Color = OklchToHex(lightness, chroma, hues[i]);
+            items[i].Color = ColorUtil.OklchToHex(lightness, chroma, hues[i]);
         }
 
         await SaveAsync();
@@ -140,7 +140,7 @@
         for (int i = 0; i < previewColors.Length; i++)
         {
             var hue = 360.0 * i / previewColors.Length;
-            previewColors[i] = OklchToHex(lightness, chroma, hue);
+            previewColors[i] = ColorUtil.OklchToHex(lightness, chroma, hue);
         }
     }
 
@@ -170,64 +170,5 @@
         }
     }
 
-    private static string OklchToHex(double l, double c, double h)
-    {
-        var hr = Math.PI * h / 180.0;
-        var a = Math.Cos(hr) * c;
-        var b = Math.Sin(hr) * c;
-
-        var l_ = l + 0.3963377774 * a + 0.2158037573 * b;
-        var m_ = l - 0.1055613458 * a - 0.0638541728 * b;
-        var s_ = l - 0.0894841775 * a - 1.2914855480 * b;
-
-        var l3 = l_ * l_ * l_;
-        var m3 = m_ * m_ * m_;
-        var s3 = s_ * s_ * s_;
-
-        var r = +4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3;
-        var g = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3;
-        var b2 = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.7076147010 * s3;
-
-        double srgb(double x) => x <= 0.0031308 ? 12.92 * x : 1.055 * Math.Pow(x, 1.0 / 2.4) - 0.055;
-
-        var rr = srgb(r);
-        var gg = srgb(g);
-        var bb = srgb(b2);
-
-        int clamp(double v) => (int)Math.Round(Math.Clamp(v, 0, 1) * 255);
-
-        return $"#{clamp(rr):X2}{clamp(gg):X2}{clamp(bb):X2}";
-    }
-
-    private static (double l, double c, double h) HexToOklch(string hex)
-    {
-        if (string.IsNullOrWhiteSpace(hex)) return (0.8, 0.1, 0);
-        if (hex.StartsWith('#')) hex = hex[1..];
-        if (hex.Length != 6) return (0.8, 0.1, 0);
-
-        var r = Convert.ToInt32(hex.Substring(0, 2), 16) / 255.0;
-        var g = Convert.ToInt32(hex.Substring(2, 2), 16) / 255.0;
-        var b = Convert.ToInt32(hex.Substring(4, 2), 16) / 255.0;
-
-        double lin(double x) => x <= 0.04045 ? x / 12.92 : Math.Pow((x + 0.055) / 1.055, 2.4);
-        r = lin(r); g = lin(g); b = lin(b);
-
-        var l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
-        var m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
-        var s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
-
-        var l_ = Math.Cbrt(l);
-        var m_ = Math.Cbrt(m);
-        var s_ = Math.Cbrt(s);
-
-        var L = 0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_;
-        var a = 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_;
-        var b2 = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_;
-
-        var C = Math.Sqrt(a * a + b2 * b2);
-        var H = Math.Atan2(b2, a) * 180.0 / Math.PI;
-        if (H < 0) H += 360.0;
-
-        return (L, C, H);
-    }
+    
 }

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -123,7 +123,8 @@
 
     private void Add()
     {
-        var item = RouletteItem.Create();
+        string? baseColor = items.Count > 0 ? items[items.Count - 1].Color : null;
+        var item = RouletteItem.Create("", baseColor);
 
         if (items.Count > 0)
         {


### PR DESCRIPTION
## 概要
- ColorUtil を追加し OKLCH 変換を共通化
- 新規項目の色を直前の項目の明度・彩度から生成
- 色一括設定ツールを ColorUtil 仕様に更新

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a271975738832cb45ae7b2aabb12b0