### PR TITLE
ボタン色の統一

### DIFF
--- a/Roulette/Pages/Color.razor
+++ b/Roulette/Pages/Color.razor
@@ -33,8 +33,8 @@
 
 <div class="mb-3 d-flex">
     <button class="btn btn-primary" @onclick="AssignEven">均等</button>
-    <button class="btn btn-secondary ms-2" @onclick="AssignRandom">ランダム</button>
-    <button class="btn btn-outline-secondary ms-auto" @onclick="Back">戻る</button>
+    <button class="btn btn-primary ms-2" @onclick="AssignRandom">ランダム</button>
+    <button class="btn btn-secondary ms-auto" @onclick="Back">戻る</button>
 </div>
 
 @code {

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -78,8 +78,7 @@
     transition: background-color 0.2s ease;
 }
 
-.start-stop-button:hover,
-.settings-button:hover {
+.start-stop-button:hover {
     background-color: #0d6efd;
     color: #fff;
 }

--- a/Roulette/Pages/Manage.razor
+++ b/Roulette/Pages/Manage.razor
@@ -40,7 +40,7 @@ else
 
 <div class="mt-3 d-flex">
     <button class="btn btn-secondary" @onclick="OpenEnv">環境設定</button>
-    <button class="btn btn-info ms-2" @onclick="OpenUsage">使い方</button>
+    <button class="btn btn-secondary ms-2" @onclick="OpenUsage">使い方</button>
 </div>
 
 <div class="release-date">


### PR DESCRIPTION
## 概要
- 色一括設定ツールのランダムボタンをプライマリカラーへ変更
- メイン画面の設定ボタンが押下時に青色になる問題を解消

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a27799d2c8832c99e34904cb482e18