### PR TITLE
CSVインポート時の項目追加と空白列の扱いを改善

### DIFF
--- a/Roulette/Pages/CsvTool.razor
+++ b/Roulette/Pages/CsvTool.razor
@@ -106,13 +106,17 @@
             var item = items.FirstOrDefault(x => x.Text == name);
             if (item is null)
             {
-                string? baseColor = items.Count > 0 ? items[^1].Color : null;
-                item = RouletteItem.Create(name, baseColor);
+                var last = items.Count > 0 ? items[^1] : null;
+                item = RouletteItem.Create(name, last?.Color);
+                if (last is not null)
+                {
+                    item.State = last.State;
+                }
                 items.Add(item);
             }
             if (colorIdx >= 0)
             {
-                var color = row[colorIdx].ToString();
+                var color = row[colorIdx].ToString().Trim();
                 if (!string.IsNullOrWhiteSpace(color)) item.Color = color;
             }
             if (countIdx >= 0)
@@ -127,7 +131,7 @@
             }
             if (stateIdx >= 0)
             {
-                var stStr = row[stateIdx].ToString();
+                var stStr = row[stateIdx].ToString().Trim();
                 if (Enum.TryParse<RouletteItemState>(stStr, out var st)) item.State = st;
             }
         }


### PR DESCRIPTION
## 概要
- CSV読み込みで存在しない項目を追加する際、直前の項目と同じ状態を引き継ぐよう修正
- CSVの各列をトリムし、空白の場合は既存値を保持するように変更

## テスト
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a65760d25c832ca6d3ea1516f2fb2d