### PR TITLE
見出し前の三角アイコンを統一し拡大

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -44,33 +44,30 @@
     </div>
 }
 
-<div class="text-center mt-2">
-    <h5 class="count-header" @onclick="ToggleCounts"><span class="triangle">@(showCounts ? "▼" : "▶")</span> 当たり回数リスト</h5>
-    @if (showCounts)
-    {
-        <table class="table table-sm count-table" style="--border-color:@borderColor;">
-            <thead>
-                <tr>
-                    <th>表示</th>
-                    <th>項目</th>
-                    <th>回数</th>
+<details class="mt-2" @onToggle="ToggleCounts" open="@showCounts">
+    <summary class="h5 text-center count-summary">当たり回数リスト</summary>
+    <table class="table table-sm count-table" style="--border-color:@borderColor;">
+        <thead>
+            <tr>
+                <th>表示</th>
+                <th>項目</th>
+                <th>回数</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in allItems)
+            {
+                <tr style="background-color:@item.Color;color:@GetContrastColor(item.Color)">
+                    <td>
+                        <span class="item-state" title="@GetStateTitle(item.State)">@GetStateIcon(item.State)</span>
+                    </td>
+                    <td>@item.Text</td>
+                    <td class="text-end">@item.Count</td>
                 </tr>
-            </thead>
-            <tbody>
-                @foreach (var item in allItems)
-                {
-                    <tr style="background-color:@item.Color;color:@GetContrastColor(item.Color)">
-                        <td>
-                            <span class="item-state" title="@GetStateTitle(item.State)">@GetStateIcon(item.State)</span>
-                        </td>
-                        <td>@item.Text</td>
-                        <td class="text-end">@item.Count</td>
-                    </tr>
-                }
-            </tbody>
-        </table>
-        }
-</div>
+            }
+        </tbody>
+    </table>
+</details>
 
 <div class="text-center mt-2">
     <button class="btn btn-secondary ms-2" @onclick="OpenManage">一覧</button>

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -45,7 +45,7 @@
 }
 
 <div class="text-center mt-2">
-    <h5 class="count-header" @onclick="ToggleCounts">当たり回数リスト @(showCounts ? "▲" : "▼")</h5>
+    <h5 class="count-header" @onclick="ToggleCounts"><span class="triangle">@(showCounts ? "▼" : "▶")</span> 当たり回数リスト</h5>
     @if (showCounts)
     {
         <table class="table table-sm count-table" style="--border-color:@borderColor;">

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -104,15 +104,9 @@
     border-bottom-color: var(--border-color);
 }
 
-.count-header {
+.count-summary {
     cursor: pointer;
     user-select: none;
-}
-
-.count-header .triangle {
-    display: inline-block;
-    font-size: 1.2em;
-    margin-right: 0.25em;
 }
 
 .item-state {

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -109,6 +109,12 @@
     user-select: none;
 }
 
+.count-header .triangle {
+    display: inline-block;
+    font-size: 1.2em;
+    margin-right: 0.25em;
+}
+
 .item-state {
     margin-left: 4px;
 }

--- a/Roulette/wwwroot/css/app.css
+++ b/Roulette/wwwroot/css/app.css
@@ -105,3 +105,8 @@ a, .btn-link {
 code {
     color: #c02d76;
 }
+
+summary::marker,
+summary::-webkit-details-marker {
+    font-size: 1.2em;
+}


### PR DESCRIPTION
## 概要
- メイン画面の当たり回数リストで三角アイコンを見出しの前に配置
- 三角アイコンのフォントサイズを少し大きくするスタイルを追加
- summary要素のマーカーサイズを全体的に拡大

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a66c0eeb28832c936c5170a673b892