### PR TITLE
details要素のトグルイベントを正しい属性名に修正

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -44,7 +44,7 @@
     </div>
 }
 
-<details class="mt-2" @onToggle="ToggleCounts" open="@showCounts">
+<details class="mt-2" @ontoggle="ToggleCounts" open="@showCounts">
     <summary class="h5 text-center count-summary">当たり回数リスト</summary>
     <table class="table table-sm count-table" style="--border-color:@borderColor;">
         <thead>


### PR DESCRIPTION
## 概要
- details要素のトグルイベント属性を `@onToggle` から `@ontoggle` に変更

## テスト
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a67f367e40832cbdcc09ea90e65589