### PR TITLE
メイン画面の当たり回数リストを設定パネル風に変更

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -45,8 +45,9 @@
 }
 
 <div class="mt-2">
-    <details open="@showCounts" @ontoggle="OnCountToggle">
-        <summary class="h5 count-header">当たり回数リスト</summary>
+    <h5 class="count-header" @onclick="ToggleCounts">@(showCounts ? "▼" : "▶") 当たり回数リスト</h5>
+    @if (showCounts)
+    {
         <table class="table table-sm count-table" style="--border-color:@borderColor;">
             <thead>
                 <tr>
@@ -68,7 +69,7 @@
                 }
             </tbody>
         </table>
-    </details>
+    }
 </div>
 
 <div class="text-center mt-2">
@@ -166,7 +167,7 @@
         await JS.InvokeVoidAsync("rouletteHelper.toggleSpin");
     }
 
-    private async Task OnCountToggle()
+    private async Task ToggleCounts()
     {
         showCounts = !showCounts;
         await SaveCountsAsync();

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -44,10 +44,9 @@
     </div>
 }
 
-<div class="text-center mt-2">
-    <h5 class="count-header" @onclick="ToggleCounts">当たり回数リスト @(showCounts ? "▲" : "▼")</h5>
-    @if (showCounts)
-    {
+<div class="mt-2">
+    <details open="@showCounts" @ontoggle="OnCountToggle">
+        <summary class="h5 count-header">当たり回数リスト</summary>
         <table class="table table-sm count-table" style="--border-color:@borderColor;">
             <thead>
                 <tr>
@@ -69,7 +68,7 @@
                 }
             </tbody>
         </table>
-        }
+    </details>
 </div>
 
 <div class="text-center mt-2">
@@ -167,7 +166,7 @@
         await JS.InvokeVoidAsync("rouletteHelper.toggleSpin");
     }
 
-    private async Task ToggleCounts()
+    private async Task OnCountToggle()
     {
         showCounts = !showCounts;
         await SaveCountsAsync();

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -45,7 +45,9 @@
 }
 
 <div class="mt-2">
-    <h5 class="count-header" @onclick="ToggleCounts">@(showCounts ? "▼" : "▶") 当たり回数リスト</h5>
+    <h5 class="count-header" @onclick="ToggleCounts">
+        <span class="triangle @(showCounts ? "open" : string.Empty)">▼</span> 当たり回数リスト
+    </h5>
     @if (showCounts)
     {
         <table class="table table-sm count-table" style="--border-color:@borderColor;">

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -116,7 +116,6 @@
 
 .count-header .triangle {
     display: inline-block;
-    transition: transform 0.2s;
     transform: rotate(-90deg);
 }
 

--- a/Roulette/Pages/Main.razor.css
+++ b/Roulette/Pages/Main.razor.css
@@ -107,8 +107,19 @@
 .count-header {
     cursor: pointer;
     user-select: none;
+    text-align: center;
 }
 
 .item-state {
     margin-left: 4px;
+}
+
+.count-header .triangle {
+    display: inline-block;
+    transition: transform 0.2s;
+    transform: rotate(-90deg);
+}
+
+.count-header .triangle.open {
+    transform: rotate(0deg);
 }


### PR DESCRIPTION
## 概要
- 当たり回数リストを`details`タグに差し替え、設定画面のツールパネルと同様の開閉に変更

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a69aed08b4832cae56cdc0ef480678