### PR TITLE
環境設定のリセットを保存時に確定するよう変更

### DIFF
--- a/Roulette/Pages/Env.razor
+++ b/Roulette/Pages/Env.razor
@@ -47,9 +47,8 @@
         settings = await AppSettings.LoadAsync(JS);
     }
 
-    private async Task Reset()
+    private void Reset()
     {
-        await AppSettings.ResetAsync(JS);
         settings = new AppSettings();
     }
 


### PR DESCRIPTION
## 概要
- 「デフォルトに戻す」ボタンを押しても保存を押すまで設定を確定しないよう修正

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ac0e816c832c9056689d49f6df69