### PR TITLE
設定削除時に確認ダイアログを表示

### DIFF
--- a/Roulette/Pages/Manage.razor
+++ b/Roulette/Pages/Manage.razor
@@ -96,7 +96,13 @@ else
     private async Task DeleteConfig(string id)
     {
         var cfg = configs.FirstOrDefault(c => c.Id == id);
-        if (cfg is not null && configs.Remove(cfg))
+        if (cfg is null) return;
+
+        var name = string.IsNullOrWhiteSpace(cfg.Name) ? "この設定" : $"『{cfg.Name}』";
+        var confirm = await JS.InvokeAsync<bool>("confirm", $"{name}を削除します。よろしいですか？");
+        if (!confirm) return;
+
+        if (configs.Remove(cfg))
         {
             await RouletteConfig.SaveAsync(JS, configs);
             StateHasChanged();


### PR DESCRIPTION
## 概要
- 設定削除時に確認ダイアログを表示するように変更

## 動作確認
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ad88f6bc832cb41ff17bb430bc94