### PR TITLE
設定ツールをdivで開閉するよう変更

### DIFF
--- a/Roulette/Pages/SettingComponents/ColorTool.razor
+++ b/Roulette/Pages/SettingComponents/ColorTool.razor
@@ -2,32 +2,41 @@
 @using System.Linq
 @using Roulette.Models
 
-<details class="mb-3">
-    <summary class="h5">色一括設定ツール</summary>
-    <div class="mb-3">
-        <label class="form-label">明度: @lightness.ToString("0.00")</label>
-        <input type="range" class="form-range" min="0" max="1" step="0.01" @bind="lightness" @bind:event="oninput" />
-    </div>
-    <div class="mb-3">
-        <label class="form-label">彩度: @chroma.ToString("0.00")</label>
-        <input type="range" class="form-range" min="0" max="0.4" step="0.01" @bind="chroma" @bind:event="oninput" />
-    </div>
-    <div class="d-flex mb-3">
-        <span>色見本:</span>
-        @foreach (var color in previewColors)
-        {
-            <div class="preview-box me-2" style="background-color:@color"></div>
-        }
-    </div>
-    <div class="mb-3 d-flex">
-        <button class="btn btn-primary" @onclick="AssignEven">均等</button>
-        <button class="btn btn-primary ms-2" @onclick="AssignRandom">ランダム</button>
-    </div>
-</details>
+<div class="mb-3">
+    <h5 class="tool-header" @onclick="ToggleOpen">
+        <span class="triangle @(open ? "open" : string.Empty)">▼</span> 色一括設定ツール
+    </h5>
+    @if (open)
+    {
+        <div class="mb-3">
+            <label class="form-label">明度: @lightness.ToString("0.00")</label>
+            <input type="range" class="form-range" min="0" max="1" step="0.01" @bind="lightness" @bind:event="oninput" />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">彩度: @chroma.ToString("0.00")</label>
+            <input type="range" class="form-range" min="0" max="0.4" step="0.01" @bind="chroma" @bind:event="oninput" />
+        </div>
+        <div class="d-flex mb-3">
+            <span>色見本:</span>
+            @foreach (var color in previewColors)
+            {
+                <div class="preview-box me-2" style="background-color:@color"></div>
+            }
+        </div>
+        <div class="mb-3 d-flex">
+            <button class="btn btn-primary" @onclick="AssignEven">均等</button>
+            <button class="btn btn-primary ms-2" @onclick="AssignRandom">ランダム</button>
+        </div>
+    }
+</div>
 
 @code {
     [Parameter] public List<RouletteItem> Items { get; set; } = new();
     [Parameter] public EventCallback OnChanged { get; set; }
+
+    private bool open;
+
+    private void ToggleOpen() => open = !open;
 
     private double _lightness = 0.8;
     private double lightness

--- a/Roulette/Pages/SettingComponents/ColorTool.razor.css
+++ b/Roulette/Pages/SettingComponents/ColorTool.razor.css
@@ -3,7 +3,16 @@
     height: 2.5rem;
     border: 1px solid #ccc;
 }
-
-summary.h5 {
+.tool-header {
     cursor: pointer;
+    user-select: none;
+}
+
+.tool-header .triangle {
+    display: inline-block;
+    transform: rotate(-90deg);
+}
+
+.tool-header .triangle.open {
+    transform: rotate(0deg);
 }

--- a/Roulette/Pages/SettingComponents/CsvTool.razor
+++ b/Roulette/Pages/SettingComponents/CsvTool.razor
@@ -5,39 +5,48 @@
 @using Roulette.Models
 @using nietras.SeparatedValues
 
-<details class="mb-3">
-    <summary class="h5">CSVツール</summary>
-    <div class="alert alert-warning">
-        <p class="mb-1">
-            <strong>設定一覧ページの「設定書き出し」とは、書き出されるファイルが異なる</strong>ことに注意してください。<br />
-            このツールは、現在開いているルーレットの項目をCSVで編集するためのものです。
-            「設定書き出し」で書きだしたファイルをここで取り込んだり、ここで書き出したファイルを設定一覧ページで読み込んだりはできません。<br />
-        </p>
-        <p class="mb-1">
-            <strong>CSV取り込みルール:</strong>
-        </p>
-        <ul class="mb-0">
-            <li>
-                <strong>項目名の列は必須</strong>ですが、他の列は無くてもいいです。
-                <ul class="mb-0">
-                    <li>既に登録されている項目と同じ項目名を読み込むと、その設定値が上書きされます。そもそも同じ項目名の項目が複数ある場合、おかしくなるので注意してください。</li>
-                    <li>同じ項目名の項目が無い場合、項目が新規作成されます。</li>
-                </ul>
-            </li>
-            <li>項目上書きの時、セルが空白だったり、そもそも列が無い設定は、登録済みの項目の値が維持されます。</li>
-        </ul>
-    </div>
-    <div class="mb-3 d-flex">
-        <button class="btn btn-secondary" @onclick="ExportCsv">CSV書き出し</button>
-        <button class="btn btn-secondary ms-2" @onclick="TriggerCsvImport">CSV読み込み</button>
-        <InputFile OnChange="ImportCsv" style="display:none" @ref="csvInput" accept=".csv,text/csv" />
-    </div>
-</details>
+<div class="mb-3">
+    <h5 class="tool-header" @onclick="ToggleOpen">
+        <span class="triangle @(open ? "open" : string.Empty)">▼</span> CSVツール
+    </h5>
+    @if (open)
+    {
+        <div class="alert alert-warning">
+            <p class="mb-1">
+                <strong>設定一覧ページの「設定書き出し」とは、書き出されるファイルが異なる</strong>ことに注意してください。<br />
+                このツールは、現在開いているルーレットの項目をCSVで編集するためのものです。
+                「設定書き出し」で書きだしたファイルをここで取り込んだり、ここで書き出したファイルを設定一覧ページで読み込んだりはできません。<br />
+            </p>
+            <p class="mb-1">
+                <strong>CSV取り込みルール:</strong>
+            </p>
+            <ul class="mb-0">
+                <li>
+                    <strong>項目名の列は必須</strong>ですが、他の列は無くてもいいです。
+                    <ul class="mb-0">
+                        <li>既に登録されている項目と同じ項目名を読み込むと、その設定値が上書きされます。そもそも同じ項目名の項目が複数ある場合、おかしくなるので注意してください。</li>
+                        <li>同じ項目名の項目が無い場合、項目が新規作成されます。</li>
+                    </ul>
+                </li>
+                <li>項目上書きの時、セルが空白だったり、そもそも列が無い設定は、登録済みの項目の値が維持されます。</li>
+            </ul>
+        </div>
+        <div class="mb-3 d-flex">
+            <button class="btn btn-secondary" @onclick="ExportCsv">CSV書き出し</button>
+            <button class="btn btn-secondary ms-2" @onclick="TriggerCsvImport">CSV読み込み</button>
+            <InputFile OnChange="ImportCsv" style="display:none" @ref="csvInput" accept=".csv,text/csv" />
+        </div>
+    }
+</div>
 
 @code {
     [Parameter] public List<RouletteItem> Items { get; set; } = new();
     [Parameter] public RouletteConfig? CurrentConfig { get; set; }
     [Parameter] public EventCallback OnChanged { get; set; }
+
+    private bool open;
+
+    private void ToggleOpen() => open = !open;
 
     private InputFile? csvInput;
 

--- a/Roulette/Pages/SettingComponents/CsvTool.razor.css
+++ b/Roulette/Pages/SettingComponents/CsvTool.razor.css
@@ -1,3 +1,13 @@
-summary.h5 {
+.tool-header {
     cursor: pointer;
+    user-select: none;
+}
+
+.tool-header .triangle {
+    display: inline-block;
+    transform: rotate(-90deg);
+}
+
+.tool-header .triangle.open {
+    transform: rotate(0deg);
 }


### PR DESCRIPTION
## 概要
- 色一括設定ツールとCSVツールから`details`タグを排除
- 三角アイコン付きの見出しをクリックして開閉できるように調整

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a6b35df3f8832c8d4ebc6a87037ceb