### PR TITLE
ToggleSection の矢印の大きさと位置を調整

### DIFF
--- a/Roulette/Components/ToggleSection.razor.css
+++ b/Roulette/Components/ToggleSection.razor.css
@@ -6,6 +6,10 @@
 .toggle-header .triangle {
     display: inline-block;
     transform: rotate(-90deg);
+    font-size: 0.85em;
+    vertical-align: middle;
+    position: relative;
+    top: -0.1em;
 }
 
 .toggle-header .triangle.open {


### PR DESCRIPTION
## 概要
- 折りたたみセクションの▼を小さめに
- 縦位置を微調整

## テスト
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ba0f058c832cbeec0b70c884a5a3