### PR TITLE
ダブルタップズーム防止の閾値を500msに調整

### DIFF
--- a/Roulette/wwwroot/js/disable-zoom.js
+++ b/Roulette/wwwroot/js/disable-zoom.js
@@ -1,8 +1,9 @@
 (function () {
   let lastTouchEnd = 0;
+  const DOUBLE_TAP_THRESHOLD = 500; // iOS detects double tap up to around 500ms
   document.addEventListener('touchend', function (e) {
     const now = Date.now();
-    if (now - lastTouchEnd <= 300) {
+    if (now - lastTouchEnd <= DOUBLE_TAP_THRESHOLD) {
       e.preventDefault();
     }
     lastTouchEnd = now;


### PR DESCRIPTION
## 概要
- iOSのダブルタップズームに対応するため、タップ間隔の判定を300msから500msに延長

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a6bea75b98832c825defc85b336614