### PR TITLE
前景色を背景色設定時に計算して保持するよう変更

### DIFF
--- a/Roulette/Models/RouletteConfig.cs
+++ b/Roulette/Models/RouletteConfig.cs
@@ -29,11 +29,11 @@ public partial class RouletteConfig
             string? prevColor = null;
             foreach (var item in cfg.Items)
             {
-                if (string.IsNullOrWhiteSpace(item.Color) || !ColorRegex().IsMatch(item.Color))
+                if (string.IsNullOrWhiteSpace(item.BackgroundColor) || !ColorRegex().IsMatch(item.BackgroundColor))
                 {
-                    item.Color = RouletteItem.RandomColor(prevColor);
+                    item.BackgroundColor = RouletteItem.RandomColor(prevColor);
                 }
-                prevColor = item.Color;
+                prevColor = item.BackgroundColor;
             }
         }
     }

--- a/Roulette/Models/RouletteItem.cs
+++ b/Roulette/Models/RouletteItem.cs
@@ -5,8 +5,19 @@ namespace Roulette.Models;
 public class RouletteItem
 {
     public string Text { get; set; } = "";
+    private string _color = "";
 
-    public string Color { get; set; } = "";
+    public string Color
+    {
+        get => _color;
+        set
+        {
+            _color = value;
+            ForegroundColor = ColorUtil.GetContrastColor(value);
+        }
+    }
+
+    public string ForegroundColor { get; set; } = "black";
 
     public int Count { get; set; }
 

--- a/Roulette/Models/RouletteItem.cs
+++ b/Roulette/Models/RouletteItem.cs
@@ -8,7 +8,6 @@ public class RouletteItem
     private string _backgroundColor = "";
     private string _legacyColor = "";
 
-    [JsonPropertyName("Color")]
     public string Color
     {
         get => _legacyColor;

--- a/Roulette/Models/RouletteItem.cs
+++ b/Roulette/Models/RouletteItem.cs
@@ -5,14 +5,30 @@ namespace Roulette.Models;
 public class RouletteItem
 {
     public string Text { get; set; } = "";
-    private string _color = "";
+    private string _backgroundColor = "";
+    private string _legacyColor = "";
 
+    [JsonPropertyName("Color")]
     public string Color
     {
-        get => _color;
+        get => _legacyColor;
         set
         {
-            _color = value;
+            _legacyColor = value;
+            if (string.IsNullOrWhiteSpace(_backgroundColor))
+            {
+                ForegroundColor = ColorUtil.GetContrastColor(value);
+            }
+        }
+    }
+
+    public string BackgroundColor
+    {
+        get => string.IsNullOrWhiteSpace(_backgroundColor) ? _legacyColor : _backgroundColor;
+        set
+        {
+            _backgroundColor = value;
+            _legacyColor = value;
             ForegroundColor = ColorUtil.GetContrastColor(value);
         }
     }
@@ -35,7 +51,7 @@ public class RouletteItem
         return new RouletteItem
         {
             Text = text,
-            Color = RandomColor(baseColor),
+            BackgroundColor = RandomColor(baseColor),
             Size = 1,
             State = RouletteItemState.Locked
         };

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -59,7 +59,7 @@
             <tbody>
                 @foreach (var item in allItems)
                 {
-                    <tr style="background-color:@item.Color;color:@item.ForegroundColor">
+                    <tr style="background-color:@item.BackgroundColor;color:@item.ForegroundColor">
                         <td class="text-center">
                             <span class="item-state" title="@GetStateTitle(item.State)">@GetStateIcon(item.State)</span>
                         </td>
@@ -194,7 +194,7 @@
         {
             var item = items[index];
             overlayText = item.Text;
-            overlayColor = item.Color;
+            overlayColor = item.BackgroundColor;
             overlayTextColor = item.ForegroundColor;
             var center = await JS.InvokeAsync<double[]>("rouletteHelper.getContainerCenter", "rouletteCanvas");
             if (center?.Length == 2)
@@ -324,7 +324,7 @@
 
     private object[] ItemsForJs()
     {
-        return items.Select(i => new { text = i.Text, color = i.Color, weight = i.Weight, textColor = i.ForegroundColor }).ToArray();
+        return items.Select(i => new { text = i.Text, color = i.BackgroundColor, weight = i.Weight, textColor = i.ForegroundColor }).ToArray();
     }
 
     private void OpenSettings()

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -59,7 +59,7 @@
             <tbody>
                 @foreach (var item in allItems)
                 {
-                    <tr style="background-color:@item.Color;color:@ColorUtil.GetContrastColor(item.Color)">
+                    <tr style="background-color:@item.Color;color:@item.ForegroundColor">
                         <td class="text-center">
                             <span class="item-state" title="@GetStateTitle(item.State)">@GetStateIcon(item.State)</span>
                         </td>
@@ -195,7 +195,7 @@
             var item = items[index];
             overlayText = item.Text;
             overlayColor = item.Color;
-            overlayTextColor = ColorUtil.GetContrastColor(item.Color);
+            overlayTextColor = item.ForegroundColor;
             var center = await JS.InvokeAsync<double[]>("rouletteHelper.getContainerCenter", "rouletteCanvas");
             if (center?.Length == 2)
             {
@@ -324,7 +324,7 @@
 
     private object[] ItemsForJs()
     {
-        return items.Select(i => new { text = i.Text, color = i.Color, weight = i.Weight }).ToArray();
+        return items.Select(i => new { text = i.Text, color = i.Color, weight = i.Weight, textColor = i.ForegroundColor }).ToArray();
     }
 
     private void OpenSettings()

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -29,9 +29,9 @@
 {
     var index = i;
     <div class="mb-2 item-row">
-        <input type="color" class="form-control color-input" @bind="items[index].Color" @bind:after="MarkDirty" />
+        <input type="color" class="form-control color-input" @bind="items[index].BackgroundColor" @bind:after="MarkDirty" />
 
-        <input class="form-control text-input" style="background-color:@items[index].Color;color:@items[index].ForegroundColor" @bind="items[index].Text" @bind:after="MarkDirty" />
+        <input class="form-control text-input" style="background-color:@items[index].BackgroundColor;color:@items[index].ForegroundColor" @bind="items[index].Text" @bind:after="MarkDirty" />
 
         <div class="control-row">
             <button class="btn btn-outline-secondary state-button" @onclick="() => ToggleState(index)" title="@GetStateTitle(items[index].State)">@GetStateIcon(items[index].State)</button>
@@ -129,7 +129,7 @@
 
     private void Add()
     {
-        string? baseColor = items.Count > 0 ? items[items.Count - 1].Color : null;
+        string? baseColor = items.Count > 0 ? items[items.Count - 1].BackgroundColor : null;
         var item = RouletteItem.Create("", baseColor);
 
         if (items.Count > 0)

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -31,7 +31,7 @@
     <div class="mb-2 item-row">
         <input type="color" class="form-control color-input" @bind="items[index].Color" @bind:after="MarkDirty" />
 
-        <input class="form-control text-input" style="background-color:@items[index].Color;color:@ColorUtil.GetContrastColor(items[index].Color)" @bind="items[index].Text" @bind:after="MarkDirty" />
+        <input class="form-control text-input" style="background-color:@items[index].Color;color:@items[index].ForegroundColor" @bind="items[index].Text" @bind:after="MarkDirty" />
 
         <div class="control-row">
             <button class="btn btn-outline-secondary state-button" @onclick="() => ToggleState(index)" title="@GetStateTitle(items[index].State)">@GetStateIcon(items[index].State)</button>

--- a/Roulette/Pages/SettingComponents/ColorTool.razor
+++ b/Roulette/Pages/SettingComponents/ColorTool.razor
@@ -62,7 +62,7 @@
     {
         if (!initialized && Items.Count > 0)
         {
-            var (l, c, _) = ColorUtil.HexToOklch(Items[^1].Color);
+            var (l, c, _) = ColorUtil.HexToOklch(Items[^1].BackgroundColor);
             _lightness = Math.Clamp(l, 0, 1);
             _chroma = Math.Clamp(c, 0, 0.4);
             UpdatePreview();
@@ -76,7 +76,7 @@
         for (int i = 0; i < Items.Count; i++)
         {
             var hue = 360.0 * i / Items.Count;
-            Items[i].Color = ColorUtil.OklchToHex(lightness, chroma, hue);
+            Items[i].BackgroundColor = ColorUtil.OklchToHex(lightness, chroma, hue);
         }
         OnChanged.InvokeAsync();
     }
@@ -97,7 +97,7 @@
 
         for (int i = 0; i < Items.Count; i++)
         {
-            Items[i].Color = ColorUtil.OklchToHex(lightness, chroma, hues[i]);
+            Items[i].BackgroundColor = ColorUtil.OklchToHex(lightness, chroma, hues[i]);
         }
         OnChanged.InvokeAsync();
     }

--- a/Roulette/Pages/SettingComponents/CsvTool.razor
+++ b/Roulette/Pages/SettingComponents/CsvTool.razor
@@ -51,7 +51,7 @@
         {
             using var row = writer.NewRow();
             row["項目名"].Set(item.Text);
-            row["背景色"].Set(item.Color);
+            row["背景色"].Set(item.BackgroundColor);
             row["当たり数"].Format(item.Count);
             row["サイズ"].Format(item.Size);
             row["表示状態"].Set(item.State.ToString());
@@ -106,7 +106,7 @@
             if (item is null)
             {
                 var last = Items.Count > 0 ? Items[^1] : null;
-                item = RouletteItem.Create(name, last?.Color);
+                item = RouletteItem.Create(name, last?.BackgroundColor);
                 if (last is not null)
                 {
                     item.State = last.State;
@@ -116,7 +116,7 @@
             if (colorIdx >= 0)
             {
                 var color = row[colorIdx].ToString().Trim();
-                if (!string.IsNullOrWhiteSpace(color)) item.Color = color;
+                if (!string.IsNullOrWhiteSpace(color)) item.BackgroundColor = color;
             }
             if (countIdx >= 0)
             {

--- a/Roulette/wwwroot/js/helper.js
+++ b/Roulette/wwwroot/js/helper.js
@@ -41,20 +41,6 @@
         }
     }
 
-    function getContrastColor(hex) {
-        if (!hex) return 'black';
-        hex = String(hex).replace(/^#/, '');
-        if (hex.length === 3) {
-            hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
-        }
-        if (hex.length !== 6) return 'black';
-        const r = parseInt(hex.substring(0, 2), 16);
-        const g = parseInt(hex.substring(2, 4), 16);
-        const b = parseInt(hex.substring(4, 6), 16);
-        const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-        return brightness > 128 ? 'black' : 'white';
-    }
-
     function drawSlice(start, end, item, index, radius, textMid) {
         ctx.beginPath();
         ctx.moveTo(0, 0);
@@ -68,7 +54,7 @@
         ctx.rotate((start + end) / 2);
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
-        ctx.fillStyle = getContrastColor(color);
+        ctx.fillStyle = item?.textColor || 'black';
         const text = item?.text || item;
         const baseSize = 16;
         const maxWidth = 2 * textMid * 0.7;


### PR DESCRIPTION
## 概要
- 項目の背景色設定時に前景色を算出して保存
- 保存した前景色を設定画面とメイン画面で利用
- ルーレット描画処理を保存済み前景色に対応

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68aa3bf24b80832cb2fe82675f78e860