### PR TITLE
設定画面の項目詳細をフォーカス時に表示するよう改良

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -50,14 +50,12 @@
                 <div class="detail-row">
                     <label class="form-label me-2 mb-0">当たり回数</label>
                     <input type="number" class="form-control count-input" @bind="items[index].Count" @bind:after="MarkDirty" />
-                </div>
-                @if (!autoAdjustSize)
-                {
-                    <div class="detail-row">
-                        <label class="form-label me-2 mb-0">表示大きさ</label>
+                    @if (!autoAdjustSize)
+                    {
+                        <label class="form-label ms-3 me-2 mb-0">大きさ</label>
                         <input type="number" step="1" class="form-control size-input" @bind="items[index].Size" @bind:after="MarkDirty" />
-                    </div>
-                }
+                    }
+                </div>
             </div>
         }
     </div>

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -33,21 +33,31 @@
 
         <input class="form-control text-input" style="background-color:@items[index].BackgroundColor;color:@items[index].ForegroundColor" @bind="items[index].Text" @bind:after="MarkDirty" @onfocus="() => activeIndex = index" />
 
+        <div class="move-buttons @(activeIndex == index ? string.Empty : "invisible")">
+            <button class="btn btn-outline-secondary" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
+            <button class="btn btn-outline-secondary ms-1" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
+        </div>
+
         @if (activeIndex == index)
         {
-            <input type="color" class="form-control color-input" @bind="items[index].BackgroundColor" @bind:after="MarkDirty" />
-
-            <div class="control-row">
-                <input type="number" class="form-control count-input" @bind="items[index].Count" @bind:after="MarkDirty" />
+            <div class="detail-container">
+                <div class="detail-row">
+                    <label class="form-label me-2 mb-0">背景色</label>
+                    <input type="color" class="form-control color-input" @bind="items[index].BackgroundColor" @bind:after="MarkDirty" />
+                </div>
+                <div class="detail-row">
+                    <label class="form-label me-2 mb-0">当たり回数</label>
+                    <input type="number" class="form-control count-input" @bind="items[index].Count" @bind:after="MarkDirty" />
+                </div>
                 @if (!autoAdjustSize)
                 {
-                    <input type="number" step="1" class="form-control size-input" @bind="items[index].Size" @bind:after="MarkDirty" />
+                    <div class="detail-row">
+                        <label class="form-label me-2 mb-0">表示大きさ</label>
+                        <input type="number" step="1" class="form-control size-input" @bind="items[index].Size" @bind:after="MarkDirty" />
+                    </div>
                 }
-                <button class="btn btn-outline-danger" @onclick="() => Remove(index)">削除</button>
+                <button class="btn btn-outline-danger mt-1" @onclick="() => Remove(index)">削除</button>
             </div>
-
-            <button class="btn btn-outline-secondary move-up-button" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
-            <button class="btn btn-outline-secondary move-down-button" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
         }
     </div>
 }

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -33,14 +33,13 @@
 
         <input class="form-control text-input" style="background-color:@items[index].BackgroundColor;color:@items[index].ForegroundColor" @bind="items[index].Text" @bind:after="MarkDirty" @onfocus="() => activeIndex = index" />
 
-        <div class="move-buttons @(activeIndex == index ? string.Empty : "invisible")">
-            <button class="btn btn-outline-secondary" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
-            <button class="btn btn-outline-secondary ms-1" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
-        </div>
-
         @if (activeIndex == index)
         {
             <div class="detail-container">
+                <div class="move-buttons">
+                    <button class="btn btn-outline-secondary" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
+                    <button class="btn btn-outline-secondary ms-1" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
+                </div>
                 <div class="detail-row">
                     <label class="form-label me-2 mb-0">背景色</label>
                     <input type="color" class="form-control color-input" @bind="items[index].BackgroundColor" @bind:after="MarkDirty" />

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -36,9 +36,12 @@
         @if (activeIndex == index)
         {
             <div class="detail-container">
-                <div class="move-buttons">
-                    <button class="btn btn-outline-secondary" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
-                    <button class="btn btn-outline-secondary ms-1" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
+                <div class="action-buttons">
+                    <button class="btn btn-outline-danger" @onclick="() => Remove(index)">削除</button>
+                    <div class="move-buttons btn-group">
+                        <button class="btn btn-outline-secondary" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
+                        <button class="btn btn-outline-secondary" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
+                    </div>
                 </div>
                 <div class="detail-row">
                     <label class="form-label me-2 mb-0">背景色</label>
@@ -55,7 +58,6 @@
                         <input type="number" step="1" class="form-control size-input" @bind="items[index].Size" @bind:after="MarkDirty" />
                     </div>
                 }
-                <button class="btn btn-outline-danger mt-1" @onclick="() => Remove(index)">削除</button>
             </div>
         }
     </div>

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -169,6 +169,14 @@
         var newIndex = index + offset;
         if (newIndex < 0 || newIndex >= items.Count) return;
         (items[newIndex], items[index]) = (items[index], items[newIndex]);
+        if (activeIndex == index)
+        {
+            activeIndex = newIndex;
+        }
+        else if (activeIndex == newIndex)
+        {
+            activeIndex = index;
+        }
         MarkDirty();
     }
 

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -29,22 +29,26 @@
 {
     var index = i;
     <div class="mb-2 item-row">
-        <input type="color" class="form-control color-input" @bind="items[index].BackgroundColor" @bind:after="MarkDirty" />
+        <button class="btn btn-outline-secondary state-button" @onclick="() => ToggleState(index)" title="@GetStateTitle(items[index].State)">@GetStateIcon(items[index].State)</button>
 
-        <input class="form-control text-input" style="background-color:@items[index].BackgroundColor;color:@items[index].ForegroundColor" @bind="items[index].Text" @bind:after="MarkDirty" />
+        <input class="form-control text-input" style="background-color:@items[index].BackgroundColor;color:@items[index].ForegroundColor" @bind="items[index].Text" @bind:after="MarkDirty" @onfocus="() => activeIndex = index" />
 
-        <div class="control-row">
-            <button class="btn btn-outline-secondary state-button" @onclick="() => ToggleState(index)" title="@GetStateTitle(items[index].State)">@GetStateIcon(items[index].State)</button>
-            <input type="number" class="form-control count-input" @bind="items[index].Count" @bind:after="MarkDirty" />
-            @if (!autoAdjustSize)
-            {
-                <input type="number" step="1" class="form-control size-input" @bind="items[index].Size" @bind:after="MarkDirty" />
-            }
-            <button class="btn btn-outline-danger" @onclick="() => Remove(index)">削除</button>
-        </div>
+        @if (activeIndex == index)
+        {
+            <input type="color" class="form-control color-input" @bind="items[index].BackgroundColor" @bind:after="MarkDirty" />
 
-        <button class="btn btn-outline-secondary move-up-button" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
-        <button class="btn btn-outline-secondary move-down-button" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
+            <div class="control-row">
+                <input type="number" class="form-control count-input" @bind="items[index].Count" @bind:after="MarkDirty" />
+                @if (!autoAdjustSize)
+                {
+                    <input type="number" step="1" class="form-control size-input" @bind="items[index].Size" @bind:after="MarkDirty" />
+                }
+                <button class="btn btn-outline-danger" @onclick="() => Remove(index)">削除</button>
+            </div>
+
+            <button class="btn btn-outline-secondary move-up-button" @onclick="() => MoveUp(index)" disabled="@(index == 0)">↑</button>
+            <button class="btn btn-outline-secondary move-down-button" @onclick="() => MoveDown(index)" disabled="@(index == items.Count - 1)">↓</button>
+        }
     </div>
 }
 
@@ -78,6 +82,7 @@
     private bool autoAdjustSize = true;
     private int itemMultiplier = 1;
     private bool isDirty = true;
+    private int? activeIndex = null;
     private void MarkDirty() => isDirty = true;
 
     private void ToggleState(int index)

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -6,13 +6,9 @@
     align-items: center;
 }
 
-    .item-row .color-input {
-        grid-row: span 2;
-        width: 2.5rem;
-        height: 100%;
-        padding: 0;
-        cursor: pointer;
-        align-self: stretch;
+    .item-row .state-button {
+        grid-column: 1;
+        grid-row: 1;
     }
 
     .item-row .text-input {
@@ -20,6 +16,16 @@
         grid-row: 1;
         width: 100%;
         min-width: 0;
+    }
+
+    .item-row .color-input {
+        grid-column: 1;
+        grid-row: 2;
+        width: 2.5rem;
+        height: 100%;
+        padding: 0;
+        cursor: pointer;
+        align-self: stretch;
     }
 
     .item-row .move-up-button {

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -1,9 +1,10 @@
+
 .item-row {
     display: grid;
     grid-template-columns: auto 1fr auto;
     grid-template-rows: auto auto;
     gap: 0;
-    align-items: center;
+    align-items: start;
 }
 
     .item-row .state-button {
@@ -18,31 +19,36 @@
         min-width: 0;
     }
 
-    .item-row .color-input {
-        grid-column: 1;
-        grid-row: 2;
-        width: 2.5rem;
-        height: 100%;
-        padding: 0;
-        cursor: pointer;
-        align-self: stretch;
-    }
-
-    .item-row .move-up-button {
+    .item-row .move-buttons {
         grid-column: 3;
         grid-row: 1;
+        display: flex;
     }
 
-    .item-row .move-down-button {
-        grid-column: 3;
-        grid-row: 2;
-    }
+        .item-row .move-buttons.invisible {
+            visibility: hidden;
+        }
 
-    .item-row .control-row {
-        grid-column: 2;
+    .item-row .detail-container {
+        grid-column: 1 / span 3;
         grid-row: 2;
         display: flex;
-        align-items: center;
+        flex-direction: column;
+        gap: 0.25rem;
+        align-items: flex-start;
+    }
+
+        .item-row .detail-row {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+    .color-input {
+        width: 2.5rem;
+        height: 2.5rem;
+        padding: 0;
+        cursor: pointer;
     }
 
 .count-input {

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -1,7 +1,7 @@
 
 .item-row {
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto 1fr;
     grid-template-rows: auto auto;
     gap: 0;
     align-items: start;
@@ -19,24 +19,19 @@
         min-width: 0;
     }
 
-    .item-row .move-buttons {
-        grid-column: 3;
-        grid-row: 1;
-        display: flex;
-    }
-
-        .item-row .move-buttons.invisible {
-            visibility: hidden;
-        }
-
     .item-row .detail-container {
-        grid-column: 1 / span 3;
+        grid-column: 1 / span 2;
         grid-row: 2;
         display: flex;
         flex-direction: column;
         gap: 0.25rem;
         align-items: flex-start;
     }
+
+        .item-row .move-buttons {
+            display: flex;
+            margin-bottom: 0.25rem;
+        }
 
         .item-row .detail-row {
             display: flex;

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -1,4 +1,5 @@
 
+
 .item-row {
     display: grid;
     grid-template-columns: auto 1fr;
@@ -26,10 +27,18 @@
         flex-direction: column;
         gap: 0.25rem;
         align-items: flex-start;
+        padding: 0.5rem;
+        margin-top: 0.25rem;
+        background-color: #f8f9fa;
+        border: 1px solid #ced4da;
+        border-radius: 0.25rem;
     }
 
-        .item-row .move-buttons {
+        .item-row .action-buttons {
             display: flex;
+            justify-content: flex-end;
+            gap: 0.25rem;
+            width: 100%;
             margin-bottom: 0.25rem;
         }
 


### PR DESCRIPTION
## 概要
- 項目のテキストボックスにフォーカスしたときのみ色や回数などの詳細コントロールが現れるよう変更

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68abcb720fe0832c9d02d7cd9a680c3b