### PR TITLE
開始色相を指定できるスライダーを追加

### DIFF
--- a/Roulette/Pages/SettingComponents/ColorTool.razor
+++ b/Roulette/Pages/SettingComponents/ColorTool.razor
@@ -74,7 +74,7 @@
         }
     }
 
-    private double _startHue;
+    private double _startHue = 0;
     private double startHue
     {
         get => _startHue;
@@ -94,10 +94,9 @@
     {
         if (!initialized && Items.Count > 0)
         {
-            var (l, c, h) = ColorUtil.HexToOklch(Items[^1].BackgroundColor);
+            var (l, c, _) = ColorUtil.HexToOklch(Items[^1].BackgroundColor);
             _lightness = Math.Clamp(l, 0, 1);
             _chroma = Math.Clamp(c, 0, 0.4);
-            _startHue = h;
             UpdatePreview();
             initialized = true;
         }

--- a/Roulette/Pages/SettingComponents/ColorTool.razor
+++ b/Roulette/Pages/SettingComponents/ColorTool.razor
@@ -8,6 +8,10 @@
             <button class="btn btn-secondary" @onclick="AssignAutoForeground">文字色を自動に設定</button>
         </div>
         <div class="mb-3">
+            <label class="form-label">開始色相: @startHue.ToString("0")</label>
+            <input type="range" class="form-range" min="0" max="360" step="1" @bind="startHue" @bind:event="oninput" />
+        </div>
+        <div class="mb-3">
             <label class="form-label">明度: @lightness.ToString("0.00")</label>
             <input type="range" class="form-range" min="0" max="1" step="0.01" @bind="lightness" @bind:event="oninput" />
         </div>
@@ -70,6 +74,17 @@
         }
     }
 
+    private double _startHue;
+    private double startHue
+    {
+        get => _startHue;
+        set
+        {
+            _startHue = value;
+            UpdatePreview();
+        }
+    }
+
     private readonly Random rand = new();
     private readonly string[] previewColors = new string[3];
     private bool initialized;
@@ -79,9 +94,10 @@
     {
         if (!initialized && Items.Count > 0)
         {
-            var (l, c, _) = ColorUtil.HexToOklch(Items[^1].BackgroundColor);
+            var (l, c, h) = ColorUtil.HexToOklch(Items[^1].BackgroundColor);
             _lightness = Math.Clamp(l, 0, 1);
             _chroma = Math.Clamp(c, 0, 0.4);
+            _startHue = h;
             UpdatePreview();
             initialized = true;
         }
@@ -92,7 +108,7 @@
         if (Items.Count == 0) return;
         for (int i = 0; i < Items.Count; i++)
         {
-            var hue = 360.0 * i / Items.Count;
+            var hue = (startHue + 360.0 * i / Items.Count) % 360.0;
             Items[i].BackgroundColor = ColorUtil.OklchToHex(lightness, chroma, hue);
         }
         OnChanged.InvokeAsync();
@@ -103,7 +119,7 @@
         if (Items.Count == 0) return;
 
         var hues = Enumerable.Range(0, Items.Count)
-            .Select(i => 360.0 * i / Items.Count)
+            .Select(i => (startHue + 360.0 * i / Items.Count) % 360.0)
             .ToList();
 
         for (int i = hues.Count - 1; i > 0; i--)
@@ -125,7 +141,7 @@
         foreach (var item in Items) item.AutoForegroundColor = false;
         for (int i = 0; i < Items.Count; i++)
         {
-            var hue = 360.0 * i / Items.Count;
+            var hue = (startHue + 360.0 * i / Items.Count) % 360.0;
             Items[i].ForegroundColor = ColorUtil.OklchToHex(lightness, chroma, hue);
         }
         OnChanged.InvokeAsync();
@@ -136,7 +152,7 @@
         if (Items.Count == 0) return;
 
         var hues = Enumerable.Range(0, Items.Count)
-            .Select(i => 360.0 * i / Items.Count)
+            .Select(i => (startHue + 360.0 * i / Items.Count) % 360.0)
             .ToList();
 
         for (int i = hues.Count - 1; i > 0; i--)
@@ -185,7 +201,7 @@
     {
         for (int i = 0; i < previewColors.Length; i++)
         {
-            var hue = 360.0 * i / previewColors.Length;
+            var hue = (startHue + 360.0 * i / previewColors.Length) % 360.0;
             previewColors[i] = ColorUtil.OklchToHex(lightness, chroma, hue);
         }
     }


### PR DESCRIPTION
## 概要
- 色設定ツールに開始色相スライダーを追加
- 均等配色時に開始色相から色を割り当てるよう変更

## テスト
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68abe50d5d80832c9c3e96fa2913c44c