### PR TITLE
新規項目追加時の文字色設定を改良

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -153,12 +153,20 @@
 
     private void Add()
     {
-        string? baseColor = items.Count > 0 ? items[items.Count - 1].BackgroundColor : null;
-        var item = RouletteItem.Create("", baseColor);
+        string? baseBgColor = items.Count > 0 ? items[items.Count - 1].BackgroundColor : null;
+        string? baseFgColor = items.Count > 0 ? items[items.Count - 1].ForegroundColor : null;
+        bool autoFg = items.Count > 0 ? items[items.Count - 1].AutoForegroundColor : true;
+        var item = RouletteItem.Create("", baseBgColor);
 
         if (items.Count > 0)
         {
             item.State = items[items.Count - 1].State;
+        }
+
+        item.AutoForegroundColor = autoFg;
+        if (!autoFg)
+        {
+            item.ForegroundColor = RouletteItem.RandomColor(baseFgColor);
         }
 
         items.Add(item);

--- a/Roulette/Pages/SettingComponents/CsvTool.razor
+++ b/Roulette/Pages/SettingComponents/CsvTool.razor
@@ -114,6 +114,11 @@
                 if (last is not null)
                 {
                     item.State = last.State;
+                    item.AutoForegroundColor = last.AutoForegroundColor;
+                    if (!item.AutoForegroundColor)
+                    {
+                        item.ForegroundColor = RouletteItem.RandomColor(last.ForegroundColor);
+                    }
                 }
                 Items.Add(item);
             }


### PR DESCRIPTION
## 概要
- 項目追加時に文字色の自動/手動設定を引き継ぐ
- 手動指定の場合は背景色同様に色相だけランダムに設定
- CSV取り込みで新規項目を作る際も同様の処理を実装

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68abe7838578832cb3d3effaab399acd