### PR TITLE
当たり回数リセットボタンをメイン画面に移動

### DIFF
--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -69,6 +69,9 @@
                 }
             </tbody>
         </table>
+        <div class="text-center mt-2">
+            <button class="btn btn-warning" @onclick="ResetAllCounts">当たり回数リセット</button>
+        </div>
     </ToggleSection>
 </div>
 
@@ -286,6 +289,21 @@
     {
         showCounts = value;
         await SaveCountsAsync();
+    }
+
+    private async Task ResetAllCounts()
+    {
+        var ok = await JS.InvokeAsync<bool>("confirm", "当たり回数をリセットしますか？");
+        if (!ok)
+        {
+            return;
+        }
+        foreach (var item in allItems)
+        {
+            item.Count = 0;
+        }
+        await SaveCountsAsync();
+        StateHasChanged();
     }
 
     private async Task SaveCountsAsync()

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -73,7 +73,6 @@
 
 <div class="mb-3 d-flex">
     <button class="btn btn-secondary" @onclick="Add">追加</button>
-    <button class="btn btn-warning ms-2" @onclick="ResetAllCounts">当たり回数リセット</button>
 </div>
 
 <ColorTool Items="items" OnChanged="MarkDirty" />
@@ -201,15 +200,6 @@
     private void MoveUp(int index) => MoveItem(index, -1);
 
     private void MoveDown(int index) => MoveItem(index, 1);
-
-    private void ResetAllCounts()
-    {
-        foreach (var item in items)
-        {
-            item.Count = 0;
-        }
-        MarkDirty();
-    }
 
     private async Task Save()
     {


### PR DESCRIPTION
## 概要
- 設定画面から当たり回数リセットボタンを削除
- メイン画面の当たり回数リスト下にリセットボタンを追加し、確認ダイアログを表示

## テスト
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68abf31283d8832cb3d1138b6021ae49