### PR TITLE
設定画面のチェックボックスをフォームスイッチに変更

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -15,7 +15,7 @@
     <input class="form-control" @bind="configName" @bind:after="MarkDirty" />
 </div>
 
-<div class="form-check mb-3">
+<div class="mb-3 form-check form-switch">
     <input class="form-check-input" type="checkbox" id="autoSize" @bind="autoAdjustSize" @bind:after="MarkDirty" />
     <label class="form-check-label" for="autoSize">大きさ自動調整</label>
 </div>
@@ -45,12 +45,11 @@
                 </div>
                 <div class="detail-row">
                     <label class="form-label me-2 mb-0">文字色</label>
-                    <input class="form-check-input me-1" type="checkbox" id="@($"fgManual{index}")" checked="@(!items[index].AutoForegroundColor)" @onchange="(e) => { items[index].AutoForegroundColor = !(bool)e.Value!; MarkDirty(); }" />
-                    @if (items[index].AutoForegroundColor)
-                    {
-                        <span class="form-label me-3 mb-0">自動</span>
-                    }
-                    else
+                    <div class="form-check form-switch me-3">
+                        <input class="form-check-input" type="checkbox" id="@($"fgAuto{index}")" @bind="items[index].AutoForegroundColor" @bind:after="MarkDirty" />
+                        <label class="form-check-label" for="@($"fgAuto{index}")">自動</label>
+                    </div>
+                    @if (!items[index].AutoForegroundColor)
                     {
                         <input type="color" class="form-control color-input me-3" @bind="items[index].ForegroundColor" @bind:after="MarkDirty" />
                     }

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -47,7 +47,10 @@
                     <label class="form-label me-2 mb-0">文字色</label>
                     <div class="form-check form-switch me-3">
                         <input class="form-check-input" type="checkbox" id="@($"fgAuto{index}")" @bind="items[index].AutoForegroundColor" @bind:after="MarkDirty" />
-                        <label class="form-check-label" for="@($"fgAuto{index}")">自動</label>
+                        @if (items[index].AutoForegroundColor)
+                        {
+                            <label class="form-check-label" for="@($"fgAuto{index}")">自動</label>
+                        }
                     </div>
                     @if (!items[index].AutoForegroundColor)
                     {

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -45,19 +45,19 @@
                 </div>
                 <div class="detail-row">
                     <label class="form-label me-2 mb-0">文字色</label>
-                    <div class="form-check form-switch me-3">
+                    <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" id="@($"fgManual{index}")" checked="@(!items[index].AutoForegroundColor)"
                                @onchange="(e) => { items[index].AutoForegroundColor = !(bool)e.Value!; MarkDirty(); }" />
                         @if (items[index].AutoForegroundColor)
                         {
-                            <label class="form-check-label" for="@($"fgManual{index}")">自動</label>
+                            <label class="form-check-label ms-3" for="@($"fgManual{index}")">自動</label>
                         }
                     </div>
                     @if (!items[index].AutoForegroundColor)
                     {
-                        <input type="color" class="form-control color-input me-3" @bind="items[index].ForegroundColor" @bind:after="MarkDirty" />
+                        <input type="color" class="form-control color-input" @bind="items[index].ForegroundColor" @bind:after="MarkDirty" />
                     }
-                    <label class="form-label me-2 mb-0">背景色</label>
+                    <label class="form-label me-2 mb-0 ms-3">背景色</label>
                     <input type="color" class="form-control color-input" @bind="items[index].BackgroundColor" @bind:after="MarkDirty" />
                 </div>
                 <div class="detail-row">

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -46,10 +46,11 @@
                 <div class="detail-row">
                     <label class="form-label me-2 mb-0">文字色</label>
                     <div class="form-check form-switch me-3">
-                        <input class="form-check-input" type="checkbox" id="@($"fgAuto{index}")" @bind="items[index].AutoForegroundColor" @bind:after="MarkDirty" />
+                        <input class="form-check-input" type="checkbox" id="@($"fgManual{index}")" checked="@(!items[index].AutoForegroundColor)"
+                               @onchange="(e) => { items[index].AutoForegroundColor = !(bool)e.Value!; MarkDirty(); }" />
                         @if (items[index].AutoForegroundColor)
                         {
-                            <label class="form-check-label" for="@($"fgAuto{index}")">自動</label>
+                            <label class="form-check-label" for="@($"fgManual{index}")">自動</label>
                         }
                     </div>
                     @if (!items[index].AutoForegroundColor)


### PR DESCRIPTION
## 概要
- 設定画面のチェックボックスを Bootstrap の form-switch へ変更
- 文字色設定の UI をスイッチ形式に変更し、色選択欄の表示を切り替え

## テスト
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68ac5eae45ec832cb31ad7840a76f567