### PR TITLE
項目追加時に設定パネルを自動表示するよう修正

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -172,6 +172,7 @@
         }
 
         items.Add(item);
+        activeIndex = items.Count - 1;
         MarkDirty();
     }
 


### PR DESCRIPTION
## 概要
- 新規項目追加時に該当項目の設定パネルを自動で開くよう変更

## テスト
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4884365c832cb0572d64c1a643dc