### PR TITLE
自動調整OFF時の補正指数適用と大きさ入力の調整

### DIFF
--- a/Roulette/Models/RouletteConfig.cs
+++ b/Roulette/Models/RouletteConfig.cs
@@ -15,6 +15,8 @@ public partial class RouletteConfig
 
     public bool AutoAdjustSize { get; set; } = true;
 
+    public double AutoAdjustExponent { get; set; } = 1.0;
+
     public int ItemMultiplier { get; set; } = 1;
 
     public bool ShowCountList { get; set; } = false;
@@ -56,6 +58,11 @@ public partial class RouletteConfig
                     {
                         cfg.AutoAdjustSize = true;
                     }
+                    if (!el.TryGetProperty("autoAdjustExponent", out _) &&
+                        !el.TryGetProperty(nameof(AutoAdjustExponent), out _))
+                    {
+                        cfg.AutoAdjustExponent = 1.0;
+                    }
                     if (!el.TryGetProperty("itemMultiplier", out _) &&
                         !el.TryGetProperty(nameof(ItemMultiplier), out _))
                     {
@@ -85,6 +92,7 @@ public partial class RouletteConfig
                     Name = kvp.Key,
                     Items = [.. kvp.Value],
                     AutoAdjustSize = true,
+                    AutoAdjustExponent = 1.0,
                     ItemMultiplier = 1
                 })];
                 EnsureItemColors(list);

--- a/Roulette/Pages/Main.razor
+++ b/Roulette/Pages/Main.razor
@@ -101,6 +101,7 @@
     private DotNetObjectReference<Main>? objRef;
     private string selectedConfig = string.Empty;
     private bool autoAdjustSize = true;
+    private double autoAdjustExponent = 1.0;
     private bool autoStop = true;
     private int DisabledItemCount => allItems.Count(i => i.State == RouletteItemState.Disabled);
 
@@ -128,6 +129,7 @@
             itemMultiplier = cfg.ItemMultiplier;
             selectedConfig = cfg.Name;
             autoAdjustSize = cfg.AutoAdjustSize;
+            autoAdjustExponent = Math.Max(0, cfg.AutoAdjustExponent);
             showCounts = cfg.ShowCountList;
 
             RebuildItems();
@@ -259,7 +261,12 @@
             foreach (var item in items)
             {
                 var count = item.Count;
-                item.Size = 1.0 / (count - min + 1);
+                var baseValue = count - min + 1;
+                if (baseValue <= 0)
+                {
+                    baseValue = 1;
+                }
+                item.Size = Math.Pow(baseValue, -autoAdjustExponent);
                 item.Weight = item.Size;
             }
         }
@@ -267,7 +274,19 @@
         {
             foreach (var item in items)
             {
-                item.Weight = item.Size > 0 ? item.Size : 1;
+                if (item.Size <= 0)
+                {
+                    item.Weight = 0;
+                    continue;
+                }
+
+                var weight = Math.Pow(item.Size, autoAdjustExponent);
+                if (double.IsNaN(weight) || double.IsInfinity(weight))
+                {
+                    weight = double.MaxValue;
+                }
+
+                item.Weight = weight;
             }
         }
     }

--- a/Roulette/Pages/Manage.razor
+++ b/Roulette/Pages/Manage.razor
@@ -88,7 +88,8 @@ else
 		{
 			cfg.Name,
 			cfg.Items,
-			cfg.AutoAdjustSize,
+                        cfg.AutoAdjustSize,
+                        cfg.AutoAdjustExponent,
 			cfg.ItemMultiplier,
 			cfg.ShowCountList
 		};

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -4,7 +4,6 @@
 @using System.Text.Json
 @using System.Collections.Generic
 @using System.Linq
-@using System.Numerics
 @using Roulette.Models
 
 <PageTitle>設定『@configName』 - ルーレット</PageTitle>
@@ -19,6 +18,12 @@
 <div class="mb-3 form-check form-switch">
     <input class="form-check-input" type="checkbox" id="autoSize" @bind="autoAdjustSize" @bind:after="OnAutoAdjustSizeChanged" />
     <label class="form-check-label" for="autoSize">大きさ自動調整</label>
+</div>
+
+<div class="mb-3">
+    <label class="form-label">大きさ補正指数</label>
+    <input type="number" class="form-control" min="0" step="0.1" @bind="autoAdjustExponent" @bind:after="OnAutoAdjustExponentChanged" />
+    <div class="form-text">1で従来通り、0に近づけると大きさの差が緩やかになります。</div>
 </div>
 
 <div class="mb-3 d-flex align-items-center">
@@ -103,6 +108,7 @@
     private RouletteConfig? currentConfig;
     private bool autoAdjustSize = true;
     private bool previousAutoAdjustSize = true;
+    private double autoAdjustExponent = 1.0;
     private int itemMultiplier = 1;
     private bool isDirty = true;
     private int? activeIndex = null;
@@ -149,6 +155,7 @@
                 items = currentConfig.Items.ToList();
                 autoAdjustSize = currentConfig.AutoAdjustSize;
                 previousAutoAdjustSize = autoAdjustSize;
+                autoAdjustExponent = currentConfig.AutoAdjustExponent;
                 itemMultiplier = currentConfig.ItemMultiplier;
             }
         }
@@ -172,6 +179,16 @@
         return Task.CompletedTask;
     }
 
+    private Task OnAutoAdjustExponentChanged()
+    {
+        if (autoAdjustExponent < 0)
+        {
+            autoAdjustExponent = 0;
+        }
+        MarkDirty();
+        return Task.CompletedTask;
+    }
+
     private void NormalizeSizesForManualInput()
     {
         if (items.Count == 0)
@@ -180,112 +197,65 @@
         }
 
         var minCount = items.Min(i => i.Count);
-        var maxCount = items.Max(i => i.Count);
-        var baseDenominator = maxCount - minCount + 1;
-
-        if (baseDenominator <= 0)
-        {
-            baseDenominator = 1;
-        }
-
-        var numerators = new List<int>(items.Count);
-        var denominators = new List<int>(items.Count);
-
+        var weights = new List<double>(items.Count);
         foreach (var item in items)
         {
-            var denominator = item.Count - minCount + 1;
-            if (denominator <= 0)
+            var baseValue = item.Count - minCount + 1;
+            if (baseValue <= 0)
             {
-                denominator = 1;
+                baseValue = 1;
             }
 
-            var numerator = baseDenominator;
-            var gcd = GreatestCommonDivisor(numerator, denominator);
-            numerators.Add(numerator / gcd);
-            denominators.Add(denominator / gcd);
-        }
-
-        var lcm = denominators
-            .Where(d => d > 0)
-            .Select(d => new BigInteger(d))
-            .DefaultIfEmpty(BigInteger.One)
-            .Aggregate(Lcm);
-
-        if (lcm.IsZero)
-        {
-            return;
-        }
-
-        var weights = new List<BigInteger>(items.Count);
-        for (int i = 0; i < items.Count; i++)
-        {
-            var denominator = denominators[i];
-            if (denominator <= 0)
-            {
-                weights.Add(BigInteger.Zero);
-                continue;
-            }
-
-            var numerator = new BigInteger(numerators[i]);
-            var weight = numerator * (lcm / denominator);
+            var weight = Math.Pow(baseValue, -autoAdjustExponent);
             weights.Add(weight);
         }
 
-        var positiveWeights = weights.Where(w => w > BigInteger.Zero).ToList();
+        var positiveWeights = weights.Where(w => w > 0).ToList();
         if (positiveWeights.Count == 0)
         {
+            foreach (var item in items)
+            {
+                item.Size = 1;
+            }
             return;
         }
 
-        var gcdWeight = positiveWeights.Aggregate(BigInteger.GreatestCommonDivisor);
+        var minPositive = positiveWeights.Min();
+        if (minPositive <= 0)
+        {
+            minPositive = positiveWeights.Where(w => w > 0).DefaultIfEmpty(1).Min();
+        }
+
+        if (minPositive <= 0)
+        {
+            minPositive = 1;
+        }
+
+        var scale = 1.0 / minPositive;
 
         for (int i = 0; i < items.Count; i++)
         {
             var weight = weights[i];
-            if (weight <= BigInteger.Zero)
+            if (weight <= 0)
             {
                 items[i].Size = 0;
                 continue;
             }
 
-            if (gcdWeight > BigInteger.One)
+            var scaled = weight * scale;
+            if (double.IsInfinity(scaled) || double.IsNaN(scaled))
             {
-                weight /= gcdWeight;
+                scaled = double.MaxValue;
             }
 
-            var value = (double)weight;
-            if (double.IsInfinity(value))
+            var rounded = Math.Round(scaled, MidpointRounding.AwayFromZero);
+            if (rounded < 1)
             {
-                value = double.MaxValue;
+                rounded = 1;
             }
 
-            items[i].Size = value;
+            items[i].Size = rounded;
         }
-    }
-
-    private static int GreatestCommonDivisor(int a, int b)
-    {
-        a = Math.Abs(a);
-        b = Math.Abs(b);
-
-        while (b != 0)
-        {
-            var tmp = a % b;
-            a = b;
-            b = tmp;
-        }
-
-        return a == 0 ? 1 : a;
-    }
-
-    private static BigInteger Lcm(BigInteger a, BigInteger b)
-    {
-        if (a.IsZero || b.IsZero)
-        {
-            return BigInteger.Zero;
-        }
-
-        return BigInteger.Abs(a / BigInteger.GreatestCommonDivisor(a, b) * b);
     }
 
     private void Add()
@@ -373,6 +343,7 @@
         currentConfig.Name = configName;
         currentConfig.Items = arr;
         currentConfig.AutoAdjustSize = autoAdjustSize;
+        currentConfig.AutoAdjustExponent = autoAdjustExponent;
         currentConfig.ItemMultiplier = itemMultiplier;
 
         await RouletteConfig.SaveAsync(JS, configs);


### PR DESCRIPTION
## 概要
- 自動調整を無効にした場合でも補正指数を使って重みを算出するようにしました
- 自動調整から手動入力へ切り替える際は補正指数を反映した整数ベースの大きさを設定するようにしました
- 補正指数の入力欄を常時表示し、手動入力時のステップを整数単位に戻しました

## 動作確認
- dotnet build


------
https://chatgpt.com/codex/tasks/task_e_68d7f4089298832c85e9ade3836d6e95