### PR TITLE
設定画面のヘルプ表示を追加

### DIFF
--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -22,15 +22,16 @@
 
 <div class="mb-3">
     <div class="setting-input-group">
-        <label class="form-label mb-0 d-inline-flex align-items-center">大きさ調整指数
+        <div class="setting-input-label">
+            <label class="form-label mb-0">大きさ調整指数</label>
             <button type="button"
-                    class="help-icon-button ms-2"
+                    class="help-icon-button"
                     @onclick="ToggleAutoAdjustExponentInfo"
                     aria-expanded="@showAutoAdjustExponentInfo"
                     aria-controls="autoAdjustExponentHelp">
                 <span class="visually-hidden">大きさ調整指数の説明を@(showAutoAdjustExponentInfo ? "隠す" : "表示")</span>
             </button>
-        </label>
+        </div>
         <input type="number" class="form-control numeric-input" min="0" step="0.1" @bind="autoAdjustExponent" @bind:after="OnAutoAdjustExponentChanged" />
     </div>
     @if (showAutoAdjustExponentInfo)
@@ -41,15 +42,16 @@
 
 <div class="mb-3">
     <div class="setting-input-group">
-        <label class="form-label mb-0 d-inline-flex align-items-center">表示倍数
+        <div class="setting-input-label">
+            <label class="form-label mb-0">表示倍数</label>
             <button type="button"
-                    class="help-icon-button ms-2"
+                    class="help-icon-button"
                     @onclick="ToggleItemMultiplierInfo"
                     aria-expanded="@showItemMultiplierInfo"
                     aria-controls="itemMultiplierHelp">
                 <span class="visually-hidden">表示倍数の説明を@(showItemMultiplierInfo ? "隠す" : "表示")</span>
             </button>
-        </label>
+        </div>
         <input type="number" class="form-control numeric-input" @bind="itemMultiplier" min="1" @bind:after="MarkDirty" />
     </div>
     @if (showItemMultiplierInfo)

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -22,17 +22,42 @@
 
 <div class="mb-3">
     <div class="setting-input-group">
-        <label class="form-label mb-0">大きさ調整指数</label>
+        <label class="form-label mb-0 d-inline-flex align-items-center">大きさ調整指数
+            <button type="button"
+                    class="btn btn-sm btn-link p-0 ms-2"
+                    @onclick="ToggleAutoAdjustExponentInfo"
+                    aria-expanded="@showAutoAdjustExponentInfo"
+                    aria-controls="autoAdjustExponentHelp">
+                <span aria-hidden="true">❓</span>
+                <span class="visually-hidden">大きさ調整指数の説明を@(showAutoAdjustExponentInfo ? "隠す" : "表示")</span>
+            </button>
+        </label>
         <input type="number" class="form-control numeric-input" min="0" step="0.1" @bind="autoAdjustExponent" @bind:after="OnAutoAdjustExponentChanged" />
     </div>
-    <div class="form-text">通常は1です。当たり回数により項目の大きさが変わりますが、この数値を0に近づけると大きさの差が緩やかになります。1より大きくすることもできます。</div>
+    @if (showAutoAdjustExponentInfo)
+    {
+        <div id="autoAdjustExponentHelp" class="form-text mt-1">通常は1です。当たり回数により項目の大きさが変わりますが、この数値を0に近づけると大きさの差が緩やかになります。1より大きくすることもできます。</div>
+    }
 </div>
 
 <div class="mb-3">
     <div class="setting-input-group">
-        <label class="form-label mb-0">表示倍数</label>
+        <label class="form-label mb-0 d-inline-flex align-items-center">表示倍数
+            <button type="button"
+                    class="btn btn-sm btn-link p-0 ms-2"
+                    @onclick="ToggleItemMultiplierInfo"
+                    aria-expanded="@showItemMultiplierInfo"
+                    aria-controls="itemMultiplierHelp">
+                <span aria-hidden="true">❓</span>
+                <span class="visually-hidden">表示倍数の説明を@(showItemMultiplierInfo ? "隠す" : "表示")</span>
+            </button>
+        </label>
         <input type="number" class="form-control numeric-input" @bind="itemMultiplier" min="1" @bind:after="MarkDirty" />
     </div>
+    @if (showItemMultiplierInfo)
+    {
+        <div id="itemMultiplierHelp" class="form-text mt-1">1にすると通常通りの回数で項目が表示されます。2以上にすると設定した項目の並びをその回数分だけ繰り返し、ルーレットの区切りを増やすことができます。</div>
+    }
 </div>
 
 @for (int i = 0; i < items.Count; i++)
@@ -116,6 +141,8 @@
     private int itemMultiplier = 1;
     private bool isDirty = true;
     private int? activeIndex = null;
+    private bool showAutoAdjustExponentInfo;
+    private bool showItemMultiplierInfo;
     private void MarkDirty() => isDirty = true;
 
     private void ToggleState(int index)
@@ -192,6 +219,10 @@
         MarkDirty();
         return Task.CompletedTask;
     }
+
+    private void ToggleAutoAdjustExponentInfo() => showAutoAdjustExponentInfo = !showAutoAdjustExponentInfo;
+
+    private void ToggleItemMultiplierInfo() => showItemMultiplierInfo = !showItemMultiplierInfo;
 
     private void NormalizeSizesForManualInput()
     {

--- a/Roulette/Pages/Setting.razor
+++ b/Roulette/Pages/Setting.razor
@@ -24,11 +24,10 @@
     <div class="setting-input-group">
         <label class="form-label mb-0 d-inline-flex align-items-center">大きさ調整指数
             <button type="button"
-                    class="btn btn-sm btn-link p-0 ms-2"
+                    class="help-icon-button ms-2"
                     @onclick="ToggleAutoAdjustExponentInfo"
                     aria-expanded="@showAutoAdjustExponentInfo"
                     aria-controls="autoAdjustExponentHelp">
-                <span aria-hidden="true">❓</span>
                 <span class="visually-hidden">大きさ調整指数の説明を@(showAutoAdjustExponentInfo ? "隠す" : "表示")</span>
             </button>
         </label>
@@ -44,11 +43,10 @@
     <div class="setting-input-group">
         <label class="form-label mb-0 d-inline-flex align-items-center">表示倍数
             <button type="button"
-                    class="btn btn-sm btn-link p-0 ms-2"
+                    class="help-icon-button ms-2"
                     @onclick="ToggleItemMultiplierInfo"
                     aria-expanded="@showItemMultiplierInfo"
                     aria-controls="itemMultiplierHelp">
-                <span aria-hidden="true">❓</span>
                 <span class="visually-hidden">表示倍数の説明を@(showItemMultiplierInfo ? "隠す" : "表示")</span>
             </button>
         </label>

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -68,13 +68,13 @@
 
 .numeric-input {
     text-align: right;
-    width: 6rem;
 }
 
 .setting-input-group {
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    width: 100%;
 }
 
 .setting-input-label {
@@ -88,10 +88,12 @@
 
 .setting-input-label .form-label {
     margin-bottom: 0;
+    white-space: nowrap;
 }
 
 .setting-input-group .form-control {
-    max-width: 12rem;
+    flex: 1 1 auto;
+    max-width: none;
 }
 
 .help-icon-button {

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -84,3 +84,30 @@
 .setting-input-group .form-control {
     max-width: 12rem;
 }
+
+.help-icon-button {
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background-color: transparent;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%3E%3Ccircle%20cx%3D%2712%27%20cy%3D%2712%27%20r%3D%2711%27%20fill%3D%27%230d6efd%27%2F%3E%3Cpath%20d%3D%27M12%206.5c-1.93%200-3.5%201.4-3.5%203.13h1.75c0-.78.78-1.38%201.75-1.38%201.04%200%201.75.6%201.75%201.4%200%20.55-.32.94-.92%201.33l-.8.51c-.96.61-1.28%201.12-1.28%202.12v.39h1.75v-.39c0-.46.11-.67.73-1.07l.8-.51c1.02-.65%201.42-1.36%201.42-2.32C15.95%208.04%2014.19%206.5%2012%206.5zm-.88%209.13a1.13%201.13%200%20102.26%200%201.13%201.13%200%2000-2.26%200z%27%20fill%3D%27%23ffffff%27%2F%3E%3C%2Fsvg%3E");
+    cursor: pointer;
+    transition: transform 0.2s ease;
+}
+
+.help-icon-button:hover {
+    transform: scale(1.05);
+}
+
+.help-icon-button:focus-visible {
+    outline: 2px solid var(--bs-primary);
+    outline-offset: 2px;
+}

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -77,8 +77,17 @@
     gap: 0.75rem;
 }
 
-.setting-input-group .form-label {
-    min-width: 8rem;
+.setting-input-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 8rem;
+    flex-shrink: 0;
+    gap: 0.5rem;
+}
+
+.setting-input-label .form-label {
+    margin-bottom: 0;
 }
 
 .setting-input-group .form-control {

--- a/Roulette/Pages/Setting.razor.css
+++ b/Roulette/Pages/Setting.razor.css
@@ -81,8 +81,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    width: 8rem;
-    flex-shrink: 0;
+    flex: 0 0 10rem;
     gap: 0.5rem;
 }
 
@@ -112,6 +111,7 @@
     background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2024%2024%27%3E%3Ccircle%20cx%3D%2712%27%20cy%3D%2712%27%20r%3D%2711%27%20fill%3D%27%230d6efd%27%2F%3E%3Cpath%20d%3D%27M12%206.5c-1.93%200-3.5%201.4-3.5%203.13h1.75c0-.78.78-1.38%201.75-1.38%201.04%200%201.75.6%201.75%201.4%200%20.55-.32.94-.92%201.33l-.8.51c-.96.61-1.28%201.12-1.28%202.12v.39h1.75v-.39c0-.46.11-.67.73-1.07l.8-.51c1.02-.65%201.42-1.36%201.42-2.32C15.95%208.04%2014.19%206.5%2012%206.5zm-.88%209.13a1.13%201.13%200%20102.26%200%201.13%201.13%200%2000-2.26%200z%27%20fill%3D%27%23ffffff%27%2F%3E%3C%2Fsvg%3E");
     cursor: pointer;
     transition: transform 0.2s ease;
+    flex-shrink: 0;
 }
 
 .help-icon-button:hover {


### PR DESCRIPTION
## 概要
- 設定画面の大きさ調整指数にヘルプアイコンを追加し、説明文を折りたたみ表示に変更
- 表示倍数にもヘルプアイコンを設けて説明文を追加

## テスト
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d8cd49bd90832c971598297d59c93b